### PR TITLE
Info/project contributions

### DIFF
--- a/Maverick/UI/Tabs/Settings/Settings.swift
+++ b/Maverick/UI/Tabs/Settings/Settings.swift
@@ -57,6 +57,19 @@ struct Settings: View {
                     ProjectInfo()
                 }
             }
+            
+            VStack {
+                Image(systemName: "info.circle")
+                    .font(.largeTitle)
+                    .padding()
+                    
+                Text("App Version: \(Bundle.main.appVersion)")
+                    .font(.headline)
+                
+                Text("Build Number: \(Bundle.main.buildNumber)")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
         }
     }
     
@@ -145,5 +158,15 @@ struct AdaptiveProminentButtonModifier: ViewModifier {
             content
                 .buttonStyle(.borderedProminent)
         }
+    }
+}
+
+extension Bundle {
+    var appVersion: String {
+        return infoDictionary?["CFBundleShortVersionString"] as? String ?? "N/A"
+    }
+    
+    var buildNumber: String {
+        return infoDictionary?["CFBundleVersion"] as? String ?? "N/A"
     }
 }


### PR DESCRIPTION
New Settings look with sections dedicated to each category.

<img width="521" height="826" alt="RP-settings-contributions" src="https://github.com/user-attachments/assets/13c00929-ff77-4fee-8a29-bd10f1251561" />

