### PR TITLE
v1.8.2: Video support, AttachmentManager, v4 wire format, tmp hygiene

### DIFF
--- a/Docs/Audit/SECURITY_CHECKLIST.md
+++ b/Docs/Audit/SECURITY_CHECKLIST.md
@@ -39,6 +39,10 @@ Run through every item before tagging a release. Each item is binary — check i
 - [ ] Shared container files (`group.com.occulta.shared/inbound/*.occ`) use `.completeFileProtection`
 - [ ] Inbound `.occ` file is deleted from shared container after `processInboundSession` completes (success *and* failure paths)
 - [ ] No sensitive material written to `UserDefaults`, `NSCache`, or temp files without protection class
+- [ ] All writes to `FileManager.temporaryDirectory` use `Data.writeProtected(to:)` (`.completeFileProtection`) — no bare `write(to:)` calls
+- [ ] `FileManager.clearTemporaryDirectory()` is called on every app launch — verify it runs before any UI is shown
+- [ ] Compose staging files (media/attachments added but not yet encrypted) are removed on view disappear, encrypt-and-share completion, and individual message delete
+- [ ] Outbound `.occ` files in `temporaryDirectory` are deleted by `ActivityView.onComplete` regardless of whether the user completed the share
 
 ## 5. Share Extension
 
@@ -46,6 +50,10 @@ Run through every item before tagging a release. Each item is binary — check i
 - [ ] Extension writes only to its designated shared-container subdirectory, never to app-group root
 - [ ] `occulta://inbound?session=<uuid>` URL contains only the UUID — no key material or plaintext in the URL
 - [ ] Extension does not cache or log the ciphertext bytes
+- [ ] Session files in `pending/<sessionID>/` are AES-GCM encrypted with `ShareIndexKeyManager` before being written to disk — no plaintext attachment ever lands in the shared container
+- [ ] Main app decrypts session files via `ShareIndexKeyManager` before EXIF stripping and bundle encryption, and zeroes the ciphertext buffer after decryption
+- [ ] Session directory (`pending/<sessionID>/`) is deleted immediately after `processShareSession` completes — on both success and failure paths
+- [ ] On app launch, any `pending/` directories surviving from a previous crash are swept and deleted before processing any new session
 
 ## 6. Build Configuration
 

--- a/Docs/Features/Bundle/SPEC.md
+++ b/Docs/Features/Bundle/SPEC.md
@@ -1,0 +1,410 @@
+# Bundle Wire Format v4 — Specification
+
+**Status:** Ready for implementation  
+**Replaces:** `v3fs` JSON serialisation throughout the encryption pipeline  
+**Related:** `Docs/Features/Crypto/bundle.md` (protocol overview), `Docs/Features/Rust Package/RUST_PACKAGES_SPEC.md`
+
+---
+
+## 1. Problem
+
+Encrypting a 200 MB attachment (e.g. a video) currently produces a `.occ` file of ~474 MB — a 2.37× size increase. This is not inherent cryptographic overhead. AES-256-GCM adds exactly 28 bytes (12-byte nonce + 16-byte tag). The inflation comes entirely from serialisation.
+
+### Root Cause
+
+`OccultaBundle` and its nested types are `Codable` structs serialised via `JSONEncoder`. `Data` fields have no native JSON representation, so Foundation encodes every `Data` value as a base64 string (4/3 the size of the raw bytes). The encryption pipeline nests `Data`-in-`Codable` at three independent layers, and each layer is unaware that its input already contains binary-encoded content:
+
+| Layer | Call site | What inflates |
+|---|---|---|
+| 1 — Basket | `ComposableMessage.swift:521` `JSONEncoder().encode(basket)` | `File.content: Data?` → base64 |
+| 2 — SealedPayload | `Contact+Manager.swift:955` `JSONEncoder().encode(sealedPayload)` | `SealedPayload.message: Data` → base64 |
+| 3 — OccultaBundle | `OccultaBundle.swift:397` `JSONEncoder().encode(self)` | `OccultaBundle.ciphertext: Data` → base64 |
+
+Net factor: (4/3)³ ≈ 2.37×. For a 200 MB file: 200 MB → ~267 MB (layer 1) → ~356 MB (layer 2) → ~474 MB (layer 3).
+
+---
+
+## 2. Solution Overview
+
+Replace all three `JSONEncoder` calls on large `Data` fields with a **binary wire format** that carries raw bytes directly. The result:
+
+- 200 MB file → ~200 MB `.occ` + ~1 KB overhead (metadata headers)
+- AES-GCM's inherent 28-byte overhead is the only non-content addition
+
+The binary format is implemented in a new `WireHandle` struct. The existing `OccultaBundle` struct remains the in-memory representation used throughout `ContactManager` and `Manager.Crypto` — `WireHandle` is purely a codec layer.
+
+`WireHandle` is designed so that when the Rust package (`occulta-protocol`) is implemented, each method body becomes a single FFI call. The binary layout documented here is the Rust module's API contract.
+
+---
+
+## 3. Versioning
+
+### 3.1 New version: v4
+
+The binary format is a wire-breaking change and requires a new version value.
+
+Add `.v4` to `OccultaBundle.Version`:
+
+```swift
+enum Version: String, Codable {
+    case v1
+    case v2
+    case v3fs
+    case v4        // binary wire format — this spec
+    case unsupported
+}
+```
+
+Update `currentVersion`:
+
+```swift
+static let currentVersion: Version = .v4
+```
+
+> **Note:** The existing comment at `OccultaBundle.swift:86–88` warns against adding `Version` cases for new features. A wire-format correction is the intended use of a version bump — the prohibition applies to routing new features through the outer version rather than inside `SealedPayload`. This change is explicitly exempt.
+
+### 3.2 Version byte table
+
+| `Version` case | String raw value | Binary byte | Status |
+|---|---|---|---|
+| `.v1` | `"v1"` | — | Legacy JSON, no forward secrecy |
+| `.v2` | `"v2"` | — | Never shipped |
+| `.v3fs` | `"v3fs"` | — | JSON format, current deployed |
+| `.v4` | `"v4"` | `0x04` | Binary format, this spec |
+| `.unsupported` | _(any unknown)_ | _(any unknown byte)_ | Reject |
+
+### 3.3 Mode byte table
+
+| `Mode` case | Binary byte |
+|---|---|
+| `.forwardSecret` | `0x01` |
+| `.forwardSecretNoPQ` | `0x02` |
+| `.longTermFallback` | `0x03` |
+| `.longTermNoPQ` | `0x04` |
+| `.unsupported` | _(any unrecognised byte)_ → reject |
+
+---
+
+## 4. Wire Layout
+
+All multi-byte integers are **big-endian**. All fixed-width fields are mandatory. Optional fields use a presence byte followed by the value (or zeros if absent).
+
+### 4.1 Outer Envelope (`OccultaBundle`)
+
+```
+Offset  Size  Field
+──────  ────  ─────────────────────────────────────────────────────────
+0       4     magic: 0x4F 0x43 0x43 0x42  ("OCCB")
+4       1     version: u8                  (0x04 for v4)
+5       1     min_reader_version: u8       (minimum version to decode this bundle)
+6       1     mode: u8                     (see §3.3)
+7       2     flags: u16                   (reserved — write 0x0000, ignore on read)
+9       1     has_prekey_id: u8            (0x00 = absent, 0x01 = present)
+10      36    prekey_id: bytes             (UTF-8 UUID string, 36 bytes; zeros if absent)
+46      65    ephemeral_key: bytes         (x963 uncompressed P-256, 65 bytes; zeros on longTerm paths)
+111     16    fingerprint_nonce: bytes
+127     32    sender_fingerprint: bytes    (SHA-256(senderPub ∥ nonce))
+159     8     ciphertext_length: u64
+167     N     ciphertext: bytes            (AES-GCM combined: nonce(12) ∥ ct(N-28) ∥ tag(16))
+167+N   …     TLV sections (optional, see §4.4)
+```
+
+Total fixed header: 167 bytes.
+
+### 4.2 Inner Payload (`SealedPayload`)
+
+This is the plaintext that is passed directly to `AES.GCM.seal`. It contains two sections: a metadata JSON block and the raw message bytes.
+
+```
+Offset  Size  Field
+──────  ────  ──────────────────────────────────────────────────────────
+0       4     metadata_length: u32
+4       N     metadata_json: UTF-8 JSON object (see §4.2.1)
+4+N     8     message_length: u64
+12+N    M     message: raw binary Basket bytes (see §4.3)
+```
+
+#### 4.2.1 `metadata_json` schema
+
+All fields are optional. Absent fields are omitted (not null). Receivers treat unknown fields as no-ops.
+
+```json
+{
+  "appVersion":         "1.9.0",
+  "prekeyBatch":        { "generatedAt": 1234567890.0, "prekeys": [...] },
+  "identityChallenge":  { ... },
+  "shardOperations":    [ ... ],
+  "custodyManifest":    [ "uuid-string", ... ],
+  "expectedShards":     [ "uuid-string", ... ]
+}
+```
+
+`appVersion` is the sender's current app version string (e.g. `"1.9.0"`). Receivers use this to update the contact's stored `maxBundleVersion`. See §6.
+
+### 4.3 Basket
+
+This is what `SealedPayload.message` contains. It encodes a `Basket` struct as a length-prefixed sequence of files, each split into metadata (JSON) and raw content bytes.
+
+```
+Offset  Size  Field
+──────  ────  ──────────────────────────────────────────────────────────
+0       4     file_count: u32
+
+For each file:
+  0     4     metadata_length: u32
+  4     N     metadata_json: UTF-8 JSON object (see §4.3.1)
+  4+N   8     content_length: u64             (0 if File.content is nil)
+  12+N  M     content: raw bytes              (omitted if content_length == 0)
+```
+
+#### 4.3.1 File `metadata_json` schema
+
+```json
+{
+  "id":     "uuid-string",
+  "format": "text" | { "file": { "name": "...", "extension": "...", "note": "..." } } | "contacts" | "link",
+  "date":   1234567890.0
+}
+```
+
+`content` bytes carry the raw file data (video bytes, image bytes, UTF-8 text, etc.) with no encoding.
+
+### 4.4 TLV Extension Sections
+
+Optional sections appended after the ciphertext. Parsers that do not recognise a section type **must** skip it using `section_length`. Parsers **must not** reject a bundle solely because it contains unknown section types.
+
+```
+Offset  Size  Field
+──────  ────  ──────────────────────────────────────────────────────────
+0       1     section_type: u8
+1       4     section_length: u32
+5       N     section_bytes
+```
+
+No section types are defined for v4. Reserved for future use.
+
+---
+
+## 5. Additional Authenticated Data (AAD)
+
+The AAD computation is unchanged from v3fs. Both sender and receiver compute:
+
+```
+AAD = "v4".data(using: .utf8)! + JSONEncoder(.sortedKeys).encode(SecrecyContext)
+```
+
+Where `SecrecyContext` is reconstructed from the parsed outer envelope fields (`mode`, `ephemeralKey`, `prekeyID`). The JSON encoding is kept for AAD even though the wire format is binary — the AAD is tiny (<200 bytes) and the `.sortedKeys` guarantee makes it deterministic across all platforms without additional implementation work.
+
+Any modification to `version`, `mode`, `ephemeralKey`, or `prekeyID` in the outer envelope causes `AES.GCM.open` to throw. The `fingerprintNonce` and `senderFingerprint` fields are intentionally excluded from AAD — tampering with them makes the bundle unroutable but cannot break the ciphertext.
+
+---
+
+## 6. Per-Contact Capability Negotiation
+
+Senders choose the wire format based on what each contact's app can handle. This eliminates the need for a staged rollout — senders never transmit a format the recipient cannot read.
+
+### 6.1 Stored field
+
+Add `maxBundleVersion` to `Contact.Profile`:
+
+```swift
+var maxBundleVersion: Data?   // encrypted — nil means unknown (treat as v3fs)
+```
+
+This field is encrypted with the same local AES-GCM scheme as all other contact fields. It is **never** stored or transmitted in plaintext.
+
+The raw (decrypted) value is a single `UInt8`:
+- `nil` / absent → treat as `0x03` (v3fs)
+- `0x04` → contact can handle v4 binary format
+
+### 6.2 Deriving format on send
+
+```swift
+// In encryptBundle, before encoding the SealedPayload:
+let version: OccultaBundle.Version
+if let encrypted = contact.maxBundleVersion,
+   let raw = try? cryptoOps.decrypt(data: encrypted),
+   raw.first == 0x04 {
+    version = .v4
+} else {
+    version = .v3fs   // unknown or old contact — safe default
+}
+```
+
+### 6.3 Updating on receive
+
+After a successful `decryptSealed`, extract `appVersion` from the decoded `SealedPayload` metadata and derive the contact's maximum supported bundle version:
+
+```swift
+// In decryptSealed, after decoding the payload:
+if let appVersion = decodedPayload.appVersion {
+    let maxVersion = Self.bundleVersion(forAppVersion: appVersion)
+    let encrypted = try cryptoOps.encrypt(data: Data([maxVersion]))
+    sender.maxBundleVersion = encrypted
+}
+```
+
+The version derivation table:
+
+| App version | `maxBundleVersion` byte |
+|---|---|
+| < `"1.8.2"` | `0x03` (v3fs) |
+| ≥ `"1.8.2"` | `0x04` (v4 binary) |
+| unknown / nil | `0x03` (safe default) |
+
+v4 ships in app version `1.8.2`.
+
+### 6.4 Convergence
+
+The first message to a contact with no stored version always uses v3fs. After the first successful decryption of a reply, the stored version is updated. All subsequent messages use the negotiated format. Convergence takes at most one round trip.
+
+---
+
+## 7. Dispatch in `OccultaBundle`
+
+### Encoding
+
+```swift
+// OccultaBundle.swift
+func encoded(version: Version) throws -> Data {
+    switch version {
+    case .v4:
+        return try WireHandle.encode(self)
+    default:
+        return try JSONEncoder().encode(self)
+    }
+}
+```
+
+The `version` argument comes from the caller (`encryptBundle`), which resolves it from the contact's `maxBundleVersion`.
+
+### Decoding
+
+```swift
+// OccultaBundle.swift
+static func decoded(from data: Data) throws -> OccultaBundle {
+    if data.prefix(WireHandle.magic.count).elementsEqual(WireHandle.magic) {
+        return try WireHandle.parse(data)
+    }
+    return try JSONDecoder().decode(OccultaBundle.self, from: data)
+}
+```
+
+v4 receivers can read both formats. v3fs receivers that encounter a binary bundle fail with `DecodingError.dataCorrupted` — acceptable since the sender only transmits binary to confirmed v4 contacts.
+
+---
+
+## 8. `WireHandle` API
+
+```swift
+struct WireHandle {
+
+    static let magic: [UInt8] = [0x4F, 0x43, 0x43, 0x42]  // "OCCB"
+
+    // MARK: - Outer envelope
+
+    struct Bundle {
+        let version: UInt8
+        let minReaderVersion: UInt8
+        let mode: UInt8
+        let flags: UInt16           // reserved
+        let prekeyID: Data?         // 36 bytes (UTF-8 UUID) or nil
+        let ephemeralKey: Data      // 65 bytes, zeros on longTerm paths
+        let fingerprintNonce: Data  // 16 bytes
+        let senderFingerprint: Data // 32 bytes
+        let ciphertext: Data        // raw AES-GCM combined
+    }
+
+    /// Parse the outer binary envelope. Does not decrypt.
+    /// Use fingerprintNonce + senderFingerprint to identify the sender before calling open.
+    static func parse(_ data: Data) throws -> Bundle
+
+    /// Decrypt the ciphertext inside a parsed bundle.
+    /// Computes AAD from bundle fields and calls AES.GCM.open.
+    static func open(_ bundle: Bundle, using key: SymmetricKey) throws -> Data
+
+    /// Encode an OccultaBundle as a binary outer envelope.
+    static func encode(_ bundle: OccultaBundle) throws -> Data
+
+    // MARK: - Inner payload (SealedPayload)
+
+    /// Encode a SealedPayload to binary. This is the plaintext passed to AES.GCM.seal.
+    /// Replaces: JSONEncoder().encode(sealedPayload) in Contact+Manager.swift:955
+    static func encode(payload: OccultaBundle.SealedPayload) throws -> Data
+
+    /// Decode binary SealedPayload bytes. Called on the plaintext returned by AES.GCM.open.
+    /// Replaces: JSONDecoder().decode(SealedPayload.self, from:) in Contact+Manager.swift:1250
+    static func decode(payload: Data) throws -> OccultaBundle.SealedPayload
+
+    // MARK: - Basket
+
+    /// Encode a Basket to binary. This becomes SealedPayload.message.
+    /// Replaces: JSONEncoder().encode(basket) in ComposableMessage.swift:521
+    static func encode(basket: Basket) throws -> Data
+
+    /// Decode binary Basket bytes. Called on SealedPayload.message after decryption.
+    /// Replaces: JSONDecoder().decode(Basket.self, from:) in the receive pipeline
+    static func decode(basket: Data) throws -> Basket
+}
+```
+
+When `occulta-protocol` (Rust) is implemented, each of these methods becomes a single FFI call. The call sites in `ContactManager` and `ComposableMessage` remain unchanged.
+
+---
+
+## 9. Call Site Changes
+
+| File | Line | Change |
+|---|---|---|
+| `ComposableMessage.swift` | 521 | `JSONEncoder().encode(basket)` → `WireHandle.encode(basket:)` (v4 contacts only) |
+| `Contact+Manager.swift` | 955 | `JSONEncoder().encode(sealedPayload)` → `WireHandle.encode(payload:)` (v4) |
+| `Contact+Manager.swift` | 964 | `bundle.encoded()` → `bundle.encoded(version: version)` |
+| `Contact+Manager.swift` | 1250 | `JSONDecoder().decode(SealedPayload.self, from:)` → `WireHandle.decode(payload:)` |
+| `OccultaBundle.swift` | 79 | `currentVersion = .v3fs` → `currentVersion = .v4` |
+| `OccultaBundle.swift` | 397 | `encoded()` → `encoded(version:)` with dispatch |
+| `OccultaBundle.swift` | 401 | `decoded(from:)` → magic prefix dispatch |
+| `OccultaBundle.swift` | 90 | Add `.v4` case to `Version` enum |
+| `Contact+Manager.swift` | 1056 | `verifyConsistency` — accept `.v4` alongside `.v3fs` |
+| `Contact.Profile` (model) | new | Add `var maxBundleVersion: Data?` (encrypted) |
+| `OccultaBundle.SealedPayload` | new | Add `let appVersion: String?` |
+
+---
+
+## 10. Compatibility Contract
+
+These rules apply to all current and future implementations of the binary format:
+
+1. **Unknown TLV section types must be skipped**, not rejected. Read `section_length` bytes and advance.
+2. **Reserved `flags` bytes must be written as `0x0000`** and ignored on read.
+3. **`min_reader_version` must be checked before any other parsing.** If the reader's version is below `min_reader_version`, throw `BundleError.unsupportedVersion` immediately.
+4. **Unknown mode bytes must be decoded as `.unsupported`** and rejected before key derivation.
+5. **`fingerprintNonce` and `senderFingerprint` are routing-only.** They are not in the AAD. Tampered values make the bundle unroutable; they cannot compromise the ciphertext.
+6. **Version numbers are monotonically increasing and never reused.** Even retired versions (v2, never shipped) retain their slot.
+
+---
+
+## 11. Size Impact
+
+| Scenario | v3fs (current) | v4 (this spec) |
+|---|---|---|
+| 200 MB video | ~474 MB | ~200 MB + ~1 KB |
+| 10 MB photo | ~23.7 MB | ~10 MB + ~1 KB |
+| 1 KB text message | ~2.4 KB | ~1 KB + ~1 KB |
+| Overhead (fixed) | (4/3)³ ≈ 2.37× | 167 B header + metadata JSON |
+
+---
+
+## 12. Rust Portability Notes
+
+The binary layout in §4 is the authoritative spec for the Rust implementation. Additional notes for the implementer:
+
+- All length fields and the `flags` field are **big-endian** (`u32::from_be_bytes`, `u64::from_be_bytes`)
+- Fixed-width fields use fixed-size Rust arrays (`[u8; 65]`, `[u8; 32]`, etc.), not `Vec<u8>`
+- `min_reader_version` and `version` sit at fixed offsets (bytes 5 and 4) — readable without parsing the rest of the header
+- `has_prekey_id` / `prekey_id` pattern avoids a length prefix for a field whose size is always exactly 36 bytes when present
+- The metadata JSON inside `SealedPayload` uses `serde_json` on the Rust side; the schema is forward-compatible (unknown keys are ignored by `#[serde(deny_unknown_fields)]` must **not** be set)
+- `appVersion` in `metadata_json` is a plain semver string — parse with `semver` crate or simple string comparison against the threshold version
+- **AAD — `prekeyID` must serialize as `null`, not be omitted.** Swift's `JSONEncoder` emits `"prekeyID":null` when the field is nil. Rust `serde` with `skip_serializing_if = "Option::is_none"` omits the key entirely, producing different AAD bytes and causing every longTerm-path `open` to fail. Do not use that attribute on `prekey_id`. Use `#[serde(default)]` on deserialize and emit `null` on serialize.
+- **AAD — `ephemeralPublicKey` base64 encoding must use RFC 4648 standard alphabet with `=` padding and no newlines.** Foundation's `JSONEncoder` uses this encoding for `Data`. In the `base64` crate this is `general_purpose::STANDARD`. URL-safe or no-pad variants produce different bytes and break cross-platform AAD.
+- **AAD cross-platform test vectors are mandatory.** Before shipping the Rust implementation, generate a set of `(SecrecyContext, AAD bytes)` pairs in Swift and assert byte-identical output from Rust. Cover: forwardSecret (non-empty ephemeralPublicKey, non-nil prekeyID), longTermFallback (empty ephemeralPublicKey, nil prekeyID → `null`).
+- **`open` takes raw key bytes, not a typed key.** `SymmetricKey` is CryptoKit-specific. The Swift shim extracts bytes with `key.withUnsafeBytes { Data($0) }` before the FFI call. Rust signature: `fn open(bundle: &Bundle, key: &[u8; 32]) -> Result<Vec<u8>, BundleError>`.

--- a/Docs/Features/Import/Large Video Import — OOM Investigation.md
+++ b/Docs/Features/Import/Large Video Import — OOM Investigation.md
@@ -1,0 +1,219 @@
+# Large Video Import — OOM Investigation
+
+## Background
+
+Occulta imports media from the user's Photos library and encrypts it into the `.eatt` chunked format before storing it in the app sandbox. For small files this is trivial. For large videos (~2 GB) the app was crashing with a foreground OOM (Jetsam termination) on every attempt.
+
+This document records the full investigation: what was tried, why each approach failed, what finally worked, and the security constraints that shaped every decision.
+
+---
+
+## Security Constraints (Non-Negotiable)
+
+Every approach was evaluated against two hard rules:
+
+1. **No plaintext files in the app sandbox.** Writing a decrypted copy of the video to a temp file — even briefly — is a forensic trace. A sophisticated analysis of the device could recover the plaintext from deleted temp files, the filesystem journal, or the unified buffer cache. This ruled out `loadFileRepresentation`, `loadTransferable(type: URL.self)`, and `PHAssetResourceManager.writeData(for:toFile:)`.
+
+2. **No unnecessary evidence of concealment.** The app should not leave artifacts that indicate something was hidden or deleted. Traces of large temp files appearing and disappearing are suspicious.
+
+These constraints meant the only acceptable path was to read source bytes directly into an encryption loop — never materialising the plaintext anywhere on disk.
+
+---
+
+## The Encryption Format
+
+Videos are stored as `.eatt` files (chunked AES-GCM):
+
+- **101-byte header**: magic, version, chunk size, chunk count, plaintext size, base nonce, key salt, HMAC-SHA256 header MAC
+- **256 KB chunks**, each independently encrypted with AES-GCM (16-byte tag appended)
+- **Per-file HKDF key** derived from the contact's symmetric key and a random salt
+- **Derived nonces** per chunk (base nonce XOR chunk index)
+
+`StreamingEncryptor` writes chunks as they arrive via `append()`, holding at most one 256 KB buffer in memory at a time. `finalize()` flushes the last partial chunk and writes the authenticated header. `F_NOCACHE` is set on the write `FileHandle` so encrypted chunks bypass the kernel's unified buffer cache on the way to disk.
+
+---
+
+## iOS Memory Model — Why 2 GB Is Hard
+
+- **No swap space.** iOS never pages anonymous memory to disk. Every byte allocated must fit in physical RAM.
+- **Jetsam.** The foreground app limit on an iPhone 11 (4 GB device) is approximately 1.5–2 GB. The kernel kills the app instantly when this is exceeded — no warning, no recovery.
+- **Unified buffer cache (UBC).** Every file read goes through the UBC by default. Sequential reads of a 2 GB file fill 2 GB of buffer cache. The kernel counts this against Jetsam limits even though it is technically evictable.
+- **`MADV_DONTNEED` is advisory on Darwin.** Unlike Linux (where it is immediate and guaranteed), on Darwin the kernel may ignore or defer it, particularly for `MAP_SHARED` file-backed mappings. It cannot be relied upon to bound physical memory.
+- **`mmap` virtual ≠ physical, but fault rate matters.** A 2 GB `mmap` region does not immediately consume 2 GB of RAM — pages are faulted in on access. However, if pages are faulted in faster than the eviction thread can reclaim them, Jetsam terminates the app.
+
+---
+
+## Approaches Tried
+
+### 1. `PHAssetResourceManager.requestData` — basic
+
+**What:** Request the video bytes via the Photos framework streaming API. Process each delivered `Data` in the `dataReceivedHandler`.
+
+**Result:** Crashed. Despite documentation implying ~1 MB deliveries, for a 1.96 GB video the handler was called with a single ~1.5 GB `Data`, then a second delivery pushed total memory to ~2.9 GB.
+
+**Why it failed:** `PHAssetResourceManager` delivers data in arbitrarily large chunks — apparently sized to the underlying file segment, not a fixed small unit. There is no way to control delivery chunk size.
+
+### 2. `PHAssetResourceManager.requestData` + `MADV_DONTNEED` on delivered chunks
+
+**What:** Same as above, but walk each delivered `Data` in 64 KB slices inside `withUnsafeBytes`, calling `madvise(MADV_DONTNEED)` after each slice.
+
+**Result:** Memory warning and crash. The delivered `Data` is heap-backed (a `malloc` allocation), not `mmap`-backed. `madvise` on heap memory is a no-op.
+
+### 3. `requestAVAsset` (.highQualityFormat) → URL → file read
+
+**What:** Use `PHImageManager.requestAVAsset` to obtain a local file URL, then read from it.
+
+**Result:** Crashed before reading started. The `.highQualityFormat` delivery mode transcode HEVC → H.264 in memory.
+
+### 4. `requestAVAsset` (.automatic) → URL → `mmap` + `MADV_DONTNEED`
+
+**What:** Use `.automatic` delivery (no transcoding), `mmap` the source file, read in 64 KB slices, call `MADV_DONTNEED` after each.
+
+**Result:** Stuck on "Loading…" then spiked to ~3 GB. `MADV_SEQUENTIAL` was set at the time, instructing the kernel to aggressively prefetch the entire file. Also suspected: AVFoundation background analysis running in parallel with our reads.
+
+After removing `MADV_SEQUENTIAL` and the `phThumbnail` call (which loaded photo metadata), the spike persisted. `MADV_DONTNEED` is not reliable on Darwin.
+
+### 5. `requestAVAsset` → URL → `Darwin.read()` in 64 KB chunks
+
+**What:** Swap `mmap` for raw POSIX `read()` syscalls.
+
+**Result:** Crashed. `F_NOCACHE` was applied to the *write* `FileHandle` (inside `StreamingEncryptor`) but **not** to the *source* file descriptor. Every `read()` call filled the kernel buffer cache. For 2 GB of sequential reads, 2 GB of buffer cache accumulated, pushing the process over the Jetsam limit.
+
+### 6. `loadInPlaceFileRepresentation`
+
+**What:** Attempt to get a file-system URL for the Photos asset without copying it, avoiding full Photos library authorization.
+
+**Result:** Photos returned: *"loadInPlaceFileRepresentationForTypeIdentifier is not supported. Use loadFileRepresentationForTypeIdentifier instead."*
+
+### 7. `loadFileRepresentation` / `loadTransferable(type: URL.self)`
+
+**What:** Let the system write the video to a temp file and provide us a URL.
+
+**Result:** Rejected on security grounds. Both create a plaintext copy of the video in the app's temp directory — a forensic trace. Ruled out regardless of memory behaviour.
+
+### 8. `NSItemProvider.loadDataRepresentation` + `MADV_DONTNEED`
+
+**What:** Load the video data via the picker's `NSItemProvider`, walk it in 64 KB slices with `madvise(MADV_DONTNEED)`.
+
+**Advantage:** Requires no Photos library authorization — the picker's implicit grant is sufficient, so no permission dialog is shown.
+
+**Result:** Not fully stress-tested at 2 GB before the investigation pivoted. The fundamental uncertainty: is the delivered `Data` `mmap`-backed or heap-backed? If heap-backed, `MADV_DONTNEED` is a no-op and the approach collapses the same way as PHAssetResourceManager. Retained as a fallback path for cases where Photos authorization is unavailable.
+
+---
+
+## What Finally Worked
+
+### Primary Path: `requestAVAsset` → POSIX read with `F_NOCACHE` + `F_RDAHEAD=0`
+
+**Key insight:** The chunked read loop itself was never the problem. The problem was *buffer cache accumulation on the read side*, which we had never addressed.
+
+**Implementation:**
+
+```swift
+// 1. Get the local file URL (requires Photos authorization)
+PHImageManager.default().requestAVAsset(forVideo: asset, options: opts) { avAsset, _, info in
+    // ua.url points to the video file in the Photos library
+}
+
+// 2. Open with POSIX open() for direct fd control
+let fd = open(videoURL.path(percentEncoded: false), O_RDONLY)
+
+// 3. Bypass the unified buffer cache on reads
+fcntl(fd, F_NOCACHE, 1)
+
+// 4. Disable kernel readahead — prevents speculative prefetch of the whole file
+//    NOTE: pass int 0 directly, NOT &someVar (pointer would be interpreted as a
+//    large non-zero integer on 64-bit, silently leaving readahead enabled)
+fcntl(fd, F_RDAHEAD, 0)
+
+// 5. Page-aligned buffer for optimal direct I/O
+var rawBuf: UnsafeMutableRawPointer? = nil
+posix_memalign(&rawBuf, Int(sysconf(_SC_PAGESIZE)), 65_536)
+
+// 6. Read loop — RSS stays flat throughout
+while true {
+    let n = read(fd, buf, 65_536)
+    if n == 0 { break }
+    // Data(bytesNoCopy:) — no heap copy; encryptor.append() copies into its
+    // 256 KB buffer, which is the only copy made
+    try encryptor.append(Data(bytesNoCopy: buf, count: n, deallocator: .none))
+}
+try encryptor.finalize()
+```
+
+**Observed behaviour:** Memory held flat at ~90 MB before, during, and throughout the entire 2 GB import. The POSIX + `F_NOCACHE` + `F_RDAHEAD=0` combination prevented any buffer cache accumulation.
+
+**Authorization:** This path requires `PHPhotoLibrary.requestAuthorization`. The permission dialog is shown once; subsequent imports reuse the existing grant.
+
+**`F_RDAHEAD` bug to avoid:** A widely circulated code sample passes `&readAhead` (a pointer) as the third argument to `fcntl(fd, F_RDAHEAD, ...)`. On a 64-bit device, this passes the *address* of the variable — a large non-zero integer — which the kernel interprets as "readahead = on", silently doing the opposite of what was intended. Always pass the integer literal `0` directly.
+
+---
+
+## The Post-Import Spike (Second Crash)
+
+After fixing the import loop, a new crash pattern appeared: memory held flat at ~90 MB for the entire 15-second import, then spiked immediately to 900 MB → 1.5 GB → 2.5 GB the moment the import finished.
+
+**Root cause:** `MessageBubble` was creating an `AVPlayer` inside `onAppear`. The moment the encrypted video was added to `messages` and the bubble appeared on screen, AVFoundation initialised and immediately invoked the `AVAssetResourceLoaderDelegate` to understand the video's container structure (moov atom, key frames, buffer-ahead). The resource loader's `while cursor < end` decryption loop had no `autoreleasepool`, so every `AES.GCM.SealedBox`, intermediate `Data`, and CryptoKit allocation accumulated for the entire duration of AVFoundation's initialisation request — easily hundreds of MB for a 2 GB video.
+
+**Fixes:**
+
+1. **Lazy player creation.** Moved `AVPlayer` initialisation from `onAppear` to an explicit tap gesture. The video bubble shows a static play button overlay until the user taps. The resource loader never runs at import time.
+
+2. **`autoreleasepool` in the resource loader loop.** Each call to `decryptChunk` now executes inside an `autoreleasepool` block, ensuring intermediate allocations are freed before the next chunk is decrypted. Peak memory per playback chunk is bounded to a few MB.
+
+3. **`F_NOCACHE` on the resource loader's `FileHandle`.** Decryption reads from the encrypted `.eatt` file no longer accumulate in the buffer cache during playback.
+
+---
+
+## Architecture Summary
+
+```
+PHPickerViewController
+    │
+    ├─ assetIdentifier present + Photos authorized
+    │       │
+    │       ├─ PHImageManager.requestAVAsset(.automatic)
+    │       │       → local file URL
+    │       │
+    │       └─ POSIX open() + F_NOCACHE + F_RDAHEAD=0
+    │               → read() 64 KB loop
+    │               → StreamingEncryptor.append()   [256 KB chunks, F_NOCACHE write]
+    │               → StreamingEncryptor.finalize() [authenticated header]
+    │               → .eatt file in app sandbox
+    │
+    └─ no assetIdentifier (fallback)
+            │
+            └─ NSItemProvider.loadDataRepresentation
+                    → MADV_DONTNEED on delivered Data (if mmap-backed)
+                    → same StreamingEncryptor path
+
+Playback:
+    MessageBubble (tap to play)
+        → AVPlayer + AVAssetResourceLoaderDelegate
+        → decryptChunk() per AVFoundation request
+            [F_NOCACHE on read handle, autoreleasepool per chunk]
+```
+
+---
+
+## Rejected Approaches and Why
+
+| Approach | Reason Rejected |
+|---|---|
+| `loadFileRepresentation` | Plaintext file in sandbox — forensic trace |
+| `loadTransferable(type: URL.self)` | Plaintext temp file — forensic trace |
+| `PHAssetResourceManager.writeData(for:toFile:)` | Plaintext file in sandbox — forensic trace |
+| `mmap` + `MADV_DONTNEED` | `MADV_DONTNEED` is advisory on Darwin; unreliable for bounded physical memory |
+| `loadInPlaceFileRepresentation` | Not supported by Photos for video assets |
+| `read()` without `F_NOCACHE` on source fd | Buffer cache accumulates full file in RAM |
+
+---
+
+## Key Lessons
+
+- **`F_NOCACHE` must be applied to both sides.** Writes were protected from the start (`StreamingEncryptor`). Reads were not, which was the primary crash cause for two months.
+- **`F_RDAHEAD=0` is a direct int, not a pointer.** A subtle API misuse silently re-enables the feature you are trying to disable.
+- **`MADV_DONTNEED` is not a substitute for `F_NOCACHE` on Darwin.** It is advisory, unreliable for `MAP_SHARED` mappings, and a no-op for heap-backed `Data`.
+- **Eager `AVPlayer` initialisation is a hidden memory cost.** AVFoundation's startup I/O for a 2 GB video is itself an OOM risk. Never create a player until the user requests playback.
+- **`autoreleasepool` in AES-GCM loops is not optional.** CryptoKit and `Data` operations produce many short-lived allocations. Without a per-iteration pool, these accumulate for the duration of the entire decryption pass.
+- **Flat memory during import does not mean success.** The first version of the POSIX fix showed a perfect flat line for 15 seconds, then crashed immediately after. The crash was in unrelated code that ran post-import. Profile the full lifecycle, not just the loop.

--- a/Docs/Features/Import/Video Transcode Pipeline — Spec.md
+++ b/Docs/Features/Import/Video Transcode Pipeline — Spec.md
@@ -1,0 +1,220 @@
+# Video Transcode Pipeline — Spec
+
+## Overview
+
+Occulta currently imports videos at original quality using a zero-plaintext POSIX read loop. For large videos (2 GB+, 4K), playback in the message bubble triggers a 1.5 GB memory spike from AVFoundation's decode pipeline — inherent to decoding 4K frames regardless of `preferredForwardBufferDuration`.
+
+This feature introduces a zero-plaintext transcode pipeline that generates a lower-resolution encrypted preview file alongside the original `.eatt`. It also lays the foundation for user-facing import quality settings where a user's chosen resolution becomes the import itself (no separate preview needed).
+
+---
+
+## Security Constraints (Non-Negotiable)
+
+Same rules as all prior import work:
+
+1. **No plaintext video data written to disk at any point.** `AVAssetExportSession` and `AVAssetWriter` both require a file URL output — both are ruled out. The transcode pipeline must operate entirely in memory.
+2. **No forensic traces.** No temp files, no copies, no APFS journal artifacts.
+
+---
+
+## Architecture
+
+### TranscodeSettings
+
+All transcode operations — preview generation and quality-capped imports alike — are driven by a single parameterised struct:
+
+```swift
+struct TranscodeSettings {
+    let resolution:    CGSize      // e.g. CGSize(width: 960, height: 540)
+    let videoBitrate:  Int         // bits per second, e.g. 2_000_000
+    let frameRateCap:  Double?     // nil = preserve original
+    let codec:         CMVideoCodecType  // kCMVideoCodecType_H264 or HEVC
+    let includeAudio:  Bool
+
+    static let preview    = TranscodeSettings(resolution: CGSize(width: 960, height: 540),
+                                              videoBitrate: 2_000_000,
+                                              frameRateCap: 30,
+                                              codec: kCMVideoCodecType_H264,
+                                              includeAudio: true)
+    static let hd1080     = TranscodeSettings(resolution: CGSize(width: 1920, height: 1080), ...)
+    static let hd720      = TranscodeSettings(resolution: CGSize(width: 1280, height: 720),  ...)
+    static let sd480      = TranscodeSettings(resolution: CGSize(width: 854,  height: 480),  ...)
+}
+```
+
+The same pipeline code runs for all presets. The settings UI (future) just populates this struct.
+
+---
+
+## Import Branches
+
+### Branch A — Original Quality (existing, unchanged)
+
+User picks video → `requestAVAsset` → POSIX `open()` + `F_NOCACHE` + `F_RDAHEAD=0` → `StreamingEncryptor` → `main.eatt`
+
+**After** `main.eatt` is written, automatically kick off Branch B with `TranscodeSettings.preview` to produce `main_preview.eatt`.
+
+### Branch B — Transcoded (new, used for both preview generation and future quality settings)
+
+User picks video → transcode pipeline → `main.eatt` at chosen resolution.
+
+When the user selects a quality preset other than Original, Branch B produces the only `.eatt` — no preview file is needed because the import itself is already small enough to play directly in the bubble.
+
+```
+[AVURLAsset URL from requestAVAsset]
+        │
+        ▼
+[AVAssetReader]
+   ├─ AVAssetReaderVideoCompositionOutput
+   │    renderSize: settings.resolution         → CVPixelBuffer (memory)
+   │         │
+   │         ▼
+   │    VTCompressionSession (H.264/HEVC)       → CMSampleBuffer (memory)
+   │         │
+   └─ AVAssetReaderTrackOutput (audio)          → CMSampleBuffer (memory, passthrough AAC)
+        │
+        ▼
+[In-Memory fMP4 Muxer]
+   Assembles ftyp + moov + repeating (moof + mdat) pairs
+   Interleaves video and audio fragments
+        │
+        ▼
+[StreamingEncryptor]                            → .eatt written to disk
+```
+
+---
+
+## fMP4 Muxer (The Hard Part)
+
+`AVAssetWriter` is ruled out (requires seekable file output). The muxer is implemented from scratch.
+
+**Output format: Fragmented MP4 (ISO 14496-12)**
+
+Fragmented MP4 requires no seeking — the `moov` box declares track parameters only, with no sample table. Samples live in self-contained `moof` + `mdat` fragment pairs. This is what HLS uses and what AVFoundation handles natively.
+
+**Box structure:**
+
+```
+ftyp  — file type declaration (mp42 / iso5)
+moov
+  mvhd  — movie header
+  trak (video)
+    tkhd
+    mdia
+      mdhd
+      hdlr (vide)
+      minf
+        vmhd
+        dinf → dref
+        stbl  — empty (no samples; all in moof/mdat)
+          stsd → avc1/hvc1 with SPS/PPS from VTCompressionSession format description
+          stts, stsc, stsz, stco (all zero-entry)
+  trak (audio, if includeAudio)
+    — same structure, stsd → mp4a
+  mvex
+    trex (video)
+    trex (audio)
+
+[repeating per keyframe group:]
+moof
+  mfhd  — sequence number
+  traf (video)
+    tfhd
+    tfdt  — decode time
+    trun  — sample table (offsets, durations, sizes, flags)
+  traf (audio, interleaved)
+    tfhd
+    tfdt
+    trun
+mdat  — raw encoded bytes (video NAL units + audio AAC frames)
+```
+
+**Key implementation details:**
+
+- SPS and PPS for H.264 are extracted from `VTCompressionSession`'s output `CMFormatDescription` on the first keyframe sample. They go into the `avc1` box's `avcC` record.
+- Decode timestamps vs. presentation timestamps: `VTCompressionSession` may reorder frames (B-frames). `CMSampleBuffer` carries both DTS and PTS. `trun` entries carry composition time offsets (`ctts`) when PTS ≠ DTS.
+- Fragment boundary: start a new `moof`/`mdat` pair on each keyframe (IDR). This is the natural HLS segment boundary and gives AVFoundation clean seek points.
+- Audio fragmentation: emit audio fragments at the same boundaries as video. AAC frames from `AVAssetReaderTrackOutput` are packed into the same `mdat` as the corresponding video fragment.
+- All multi-byte integers in MP4 boxes are big-endian.
+
+Estimated scope: 350–450 lines of careful box serialization, plus unit tests against known-good fMP4 files parsed by `mp4info` or similar.
+
+---
+
+## File Naming Convention
+
+| Scenario | Files |
+|---|---|
+| Original quality import | `media_XXXXXXXX.eatt` (4K) + `media_XXXXXXXX_preview.eatt` (960p) |
+| 1080p quality import | `media_XXXXXXXX.eatt` (1080p only — IS the preview) |
+| 720p / 480p import | `media_XXXXXXXX.eatt` (at chosen res — IS the preview) |
+
+---
+
+## Playback Selection Logic
+
+On both compose and read sides:
+
+1. Check for `[name]_preview.eatt`. If present, use it for the bubble player.
+2. Otherwise use `[name].eatt` directly (already at a playable resolution).
+
+The resource loader (`AVAssetResourceLoaderDelegate`) is unchanged — it decrypts `.eatt` chunk-by-chunk regardless of which file is targeted.
+
+---
+
+## Read Side (Recipient)
+
+The bundle contains only `main.eatt` (original quality). On first open:
+
+- If `main.eatt` is above a resolution/size threshold, run Branch B with `TranscodeSettings.preview` to generate `[name]_preview.eatt` locally.
+- Preview generation runs once in the background after the bundle is decrypted and stored. The bubble shows the thumbnail until preview generation completes (same pending bubble pattern used for import).
+
+The recipient generates their own preview — the bundle stays the same size.
+
+---
+
+## Future: User-Facing Import Settings
+
+The settings UI (a sheet presented before import begins, or in app settings as a default) populates `TranscodeSettings` and passes it into `handleMedia`. No pipeline changes required.
+
+Proposed presets:
+- **Original** — POSIX path, no transcode, preview generated automatically
+- **1080p HD** — Branch B, ~200–400 MB for a 2 GB source
+- **720p** — Branch B, ~80–150 MB
+- **480p** — Branch B, ~30–60 MB
+
+The `TranscodeSettings` static presets defined now become the menu options later.
+
+---
+
+## Expected Memory Impact
+
+| Scenario | Current | After |
+|---|---|---|
+| Import (original quality) | ~90 MB flat | ~90 MB flat + preview transcode peak (~200 MB briefly) |
+| Bubble playback (4K source) | ~1.5 GB | ~30–50 MB (playing 960p preview) |
+| Bubble playback (1080p import) | ~1.5 GB | ~150–250 MB |
+| Bubble playback (720p import) | ~1.5 GB | ~60–100 MB |
+
+---
+
+## Implementation Order
+
+1. **`TranscodeSettings` struct** — define presets, no pipeline yet
+2. **fMP4 muxer** — standalone unit, testable in isolation with a known H.264 bitstream
+3. **Transcode pipeline** — `AVAssetReader` + `VTCompressionSession` + audio passthrough → muxer → `StreamingEncryptor`
+4. **Preview generation** — wire into `handleMedia` after original import completes; name as `_preview.eatt`
+5. **Playback selection** — update resource loader call site to prefer preview file
+6. **Read-side preview generation** — trigger after bundle open if source exceeds threshold
+7. **Import settings UI** — sheet + persistence; use `TranscodeSettings` presets
+
+Steps 1–5 are the core of this feature. Steps 6–7 are independent follow-ons.
+
+---
+
+## Open Questions
+
+- **Codec for preview:** H.264 is safer for compatibility; HEVC saves ~40% size at same quality. iPhone 11 hardware-encodes both. Recommend H.264 for preview, HEVC as optional setting.
+- **Frame rate cap:** Cap preview at 30fps to reduce encoded frame count. Original quality branch preserves source frame rate.
+- **Portrait/square videos:** `renderSize` must respect source aspect ratio. Compute `renderSize` from the asset's natural size, fitting within the target resolution box.
+- **HDR:** Source 4K video may be HDR (HLG/PQ). Downsampling to SDR for preview is fine; the preview is for a 260×200 bubble.

--- a/Occulta.xcodeproj/project.pbxproj
+++ b/Occulta.xcodeproj/project.pbxproj
@@ -532,7 +532,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.aibo-cora.occulta.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -564,7 +564,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.aibo-cora.occulta.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -597,7 +597,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.aibo-cora.occulta.OccultaPreview";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -631,7 +631,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.aibo-cora.occulta.OccultaPreview";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -806,7 +806,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.aibo-cora.occulta";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -863,7 +863,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 1.8.1;
+				MARKETING_VERSION = 1.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.aibo-cora.occulta";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Occulta.xcodeproj/project.pbxproj
+++ b/Occulta.xcodeproj/project.pbxproj
@@ -520,7 +520,7 @@
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = R6F5KHKKNX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
@@ -552,7 +552,7 @@
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = R6F5KHKKNX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
@@ -583,7 +583,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = R6F5KHKKNX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OccultaPreview/Info.plist;
@@ -617,7 +617,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = R6F5KHKKNX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OccultaPreview/Info.plist;
@@ -776,7 +776,7 @@
 				CODE_SIGN_ENTITLEMENTS = Occulta/Occulta.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = R6F5KHKKNX;
 				ENABLE_APP_SANDBOX = YES;
@@ -833,7 +833,7 @@
 				CODE_SIGN_ENTITLEMENTS = Occulta/Occulta.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = R6F5KHKKNX;
 				ENABLE_APP_SANDBOX = YES;

--- a/Occulta/App/OccultaApp.swift
+++ b/Occulta/App/OccultaApp.swift
@@ -86,6 +86,7 @@ struct OccultaApp: App {
         self.shardCustodyManager = ShardCustodyManager(modelContainer: sharedModelContainer, keyManager: Manager.Key())
 
         self.migrate()
+        FileManager.default.clearTemporaryDirectory()
     }
 
     /// Run migration before any UI accesses contacts.

--- a/Occulta/App/OccultaApp.swift
+++ b/Occulta/App/OccultaApp.swift
@@ -652,7 +652,10 @@ private struct RootView: View {
 
             for entry in manifest.files {
                 let fileURL = sessionDir.appendingPathComponent(entry.filename)
-                var content = try Data(contentsOf: fileURL)
+                var ciphertext = try Data(contentsOf: fileURL)
+                var content = try keyManager.decrypt(data: ciphertext)
+                _ = ciphertext.withUnsafeMutableBytes { memset($0.baseAddress!, 0, $0.count) }
+                ciphertext = Data()
 
                 // Strip EXIF/GPS/camera metadata from images before encryption.
                 // If stripping fails (e.g. unsupported format), the original data is used —

--- a/Occulta/App/OccultaApp.swift
+++ b/Occulta/App/OccultaApp.swift
@@ -585,7 +585,7 @@ private struct RootView: View {
                     let content = file.content ?? Data()
 
                     group.addTask {
-                        try content.write(to: fileURL)
+                        try content.writeProtected(to: fileURL)
                         return Occulta.File(url: fileURL, format: file.format, date: file.date)
                     }
 
@@ -695,7 +695,7 @@ private struct RootView: View {
             let occID = UUID().uuidString.components(separatedBy: "-").last ?? "shared"
             let occURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent("\(occID).occ")
-            try occData.write(to: occURL)
+            try occData.writeProtected(to: occURL)
 
             // 5. Delete session directory — plaintext no longer needed
             try FileManager.default.removeItem(at: sessionDir)

--- a/Occulta/App/OccultaApp.swift
+++ b/Occulta/App/OccultaApp.swift
@@ -195,6 +195,11 @@ private struct RootView: View {
                 /// Dismiss
             } content: { data in
                 ComposableMessage.Conversation(mode: .read(messageOwner: data.owner), messages: .constant(data.basket.files))
+                    .onDisappear {
+                        data.basket.files.forEach { file in
+                            if let url = file.url { try? FileManager.default.removeItem(at: url) }
+                        }
+                    }
             }
             .sheet(item: self.$shareResult) { result in
                 ShareActivityView(url: result.url)

--- a/Occulta/App/OccultaApp.swift
+++ b/Occulta/App/OccultaApp.swift
@@ -495,9 +495,10 @@ private struct RootView: View {
             debugPrint("Building basket for version: \(bundle?.version.rawValue ?? "none (legacy)")")
 
             let decrypted: (plaintext: Data, ownerID: String)
+            var decodedBundleVersion: OccultaBundle.Version = .v3fs
 
             switch bundle?.version {
-            case .v3fs:
+            case .v3fs, .v4:
                 guard let bundle else {
                     throw ContactManager.Errors.messageHasNoData
                 }
@@ -544,6 +545,7 @@ private struct RootView: View {
                     )
                 }
 
+                decodedBundleVersion = bundle.version
                 decrypted = (sealed.message, ownerID)
             case .unsupported:
                 throw OccultaBundle.BundleError.unsupportedVersion
@@ -555,7 +557,12 @@ private struct RootView: View {
                 try self.passSecurityControl(identifier: decrypted.ownerID)
             }
 
-            let basket = try JSONDecoder().decode(Basket.self, from: decrypted.plaintext)
+            let basket: Basket
+            if decodedBundleVersion == .v4 {
+                basket = try WireHandle.decode(basket: decrypted.plaintext)
+            } else {
+                basket = try JSONDecoder().decode(Basket.self, from: decrypted.plaintext)
+            }
 
             // ── Write file attachments, photos, videos to temp directory ─────────────────
 
@@ -659,28 +666,20 @@ private struct RootView: View {
             }
 
             // 3. Encrypt via the full FS path — same as in-app messages
-            let basket = Basket(files: files, date: Date())
-            var basketData = try JSONEncoder().encode(basket)
-
-            let contactID  = manifest.contactIdentifier
+            let basket    = Basket(files: files, date: Date())
+            let contactID = manifest.contactIdentifier
             let contactPub = try? self.contactManager.currentPublicKey(forIdentifier: contactID)
             let shardOps   = try self.shardCustodyManager.buildShardOperations(for: contactID, currentContactPublicKey: contactPub)
             let manifest_  = try? self.shardCustodyManager.buildCustodyManifest(for: contactID)
             let expected   = try? self.shardCustodyManager.buildExpectedShards(for: contactID, vaultManager: self.vaultManager)
 
             let occData = try self.contactManager.encryptBundle(
-                data:            basketData,
+                basket:          basket,
                 for:             contactID,
                 shardOperations: shardOps.isEmpty ? nil : shardOps,
                 custodyManifest: manifest_,
                 expectedShards:  expected
             )
-
-            // Zero all plaintext buffers before deallocation.
-            // Swift Data uses COW — if Basket copied the buffers, the originals
-            // may not be the same allocation. Best-effort; Swift doesn't guarantee zeroing.
-            _ = basketData.withUnsafeMutableBytes { memset($0.baseAddress!, 0, $0.count) }
-            basketData = Data()
             for i in files.indices {
                 _ = files[i].content?.withUnsafeMutableBytes { memset($0.baseAddress!, 0, $0.count) }
             }

--- a/Occulta/App/OccultaApp.swift
+++ b/Occulta/App/OccultaApp.swift
@@ -195,7 +195,9 @@ private struct RootView: View {
             .sheet(item: self.$openedFileContents) {
                 /// Dismiss
             } content: { data in
-                ComposableMessage.Conversation(mode: .read(messageOwner: data.owner), messages: .constant(data.basket.files))
+                let manager = (try? self.contactManager.fileEncryptionKey(for: data.owner))
+                    .map { AttachmentManager(contactKey: $0) }
+                ComposableMessage.Conversation(mode: .read(messageOwner: data.owner), messages: .constant(data.basket.files), attachmentManager: manager)
                     .onDisappear {
                         data.basket.files.forEach { file in
                             if let url = file.url { try? FileManager.default.removeItem(at: url) }
@@ -573,19 +575,24 @@ private struct RootView: View {
             // ── Write file attachments, photos, videos to temp directory ─────────────────
 
             var processed: [Occulta.File] = []
-            let tempDir = FileManager.default.temporaryDirectory
+            let tempDir         = FileManager.default.temporaryDirectory
+            let attachmentManager = (try? self.contactManager.fileEncryptionKey(for: decrypted.ownerID))
+                .map { AttachmentManager(contactKey: $0) }
 
             for file in basket.files {
                 switch file.format {
                 case .file(let metadata):
-                    /// Store photos, videos and documents in temp folder if the file's content is a file
                     let fileURL = tempDir
                         .appendingPathComponent(metadata.name ?? UUID().uuidString)
                         .appendingPathExtension(metadata.extension ?? "bin")
                     let content = file.content ?? Data()
 
                     group.addTask {
-                        try content.writeProtected(to: fileURL)
+                        if let manager = attachmentManager {
+                            try manager.encrypt(content, to: fileURL)
+                        } else {
+                            try content.writeProtected(to: fileURL)
+                        }
                         return Occulta.File(url: fileURL, format: file.format, date: file.date)
                     }
 

--- a/Occulta/Data Models/Contact+Model.swift
+++ b/Occulta/Data Models/Contact+Model.swift
@@ -79,7 +79,12 @@ extension Contact {
         ///   N    — visible through duress depth N, hidden at N+1 and deeper
         /// All non-nil values are AES-GCM of a 1-byte JSON integer → identical ciphertext size.
         var visibleThroughDepth: Data? = nil
-        
+
+        /// Encrypted UInt8 — maximum bundle version this contact's app can decode.
+        /// nil = unknown, treat as v3fs on send. Derived from `appVersion` in received bundles.
+        /// SwiftData lightweight migration: new optional column, no plan required.
+        var maxBundleVersion: Data? = nil
+
         // MARK: - Full Designated Initializer
         
         init(

--- a/Occulta/Extensions/Data.swift
+++ b/Occulta/Extensions/Data.swift
@@ -12,4 +12,8 @@ extension Data {
     var sha256: Data {
         Data(self.withUnsafeBytes { Data(CryptoKit.SHA256.hash(data: $0)) })
     }
+
+    func writeProtected(to url: URL) throws {
+        try self.write(to: url, options: .completeFileProtection)
+    }
 }

--- a/Occulta/Extensions/Data.swift
+++ b/Occulta/Extensions/Data.swift
@@ -13,7 +13,14 @@ extension Data {
         Data(self.withUnsafeBytes { Data(CryptoKit.SHA256.hash(data: $0)) })
     }
 
-    func writeProtected(to url: URL) throws {
+    nonisolated func writeProtected(to url: URL) throws {
+        var url = url
+        
         try self.write(to: url, options: .completeFileProtection)
+        
+        var resourceValues = URLResourceValues()
+        
+        resourceValues.isExcludedFromBackup = true
+        try? url.setResourceValues(resourceValues)
     }
 }

--- a/Occulta/Extensions/FileManager.swift
+++ b/Occulta/Extensions/FileManager.swift
@@ -12,11 +12,9 @@ extension FileManager {
     func clearTemporaryDirectory() {
         Task.detached {
             let tempURL = self.temporaryDirectory
-            
-            let contents = try self.contentsOfDirectory(at: tempURL, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
-            
+            guard let contents = try? self.contentsOfDirectory(at: tempURL, includingPropertiesForKeys: nil, options: .skipsHiddenFiles) else { return }
             for file in contents {
-                try self.removeItem(at: file)
+                try? self.removeItem(at: file)
             }
         }
     }

--- a/Occulta/Features/Forward+Secrecy/Crypto+Manager+ForwardSecrecy.swift
+++ b/Occulta/Features/Forward+Secrecy/Crypto+Manager+ForwardSecrecy.swift
@@ -26,7 +26,7 @@ extension Manager.Crypto {
     /// ## SE ordering
     /// `keyManager.retrieveIdentity()` is the only SE read here. All SE writes
     /// (generateBatch) are done by the caller (ContactManager) before this call.
-    func seal(message: Data, contactPrekey: Prekey?, recipientMaterial: Data, quantumMaterial: QuantumKeyMaterial? = nil) throws -> OccultaBundle {
+    func seal(message: Data, contactPrekey: Prekey?, recipientMaterial: Data, quantumMaterial: QuantumKeyMaterial? = nil, version: OccultaBundle.Version = OccultaBundle.currentVersion) throws -> OccultaBundle {
         guard
             recipientMaterial.count == 65
         else {
@@ -73,22 +73,22 @@ extension Manager.Crypto {
             let secrecy = OccultaBundle.SecrecyContext(mode: mode, ephemeralPublicKey: ephemeralPublicKeyData, prekeyID: contactPrekey.id)
 
             /// Adding `version` and `secrecy` to authenticate against tampering.
-            let aad = try OccultaBundle.computeAdditionalAuthentication(version: OccultaBundle.currentVersion, secrecy: secrecy)
+            let aad = try OccultaBundle.computeAdditionalAuthentication(version: version, secrecy: secrecy)
 
             guard
                 let ciphertext = try AES.GCM.seal(message, using: sessionKey, nonce: AES.GCM.Nonce(), authenticating: aad).combined
             else { throw EncryptionError.sealFailed }
 
             debugPrint("Sealing message, using forward secrecy prekey...")
-            
-            return OccultaBundle(version: OccultaBundle.currentVersion, secrecy: secrecy, ciphertext: ciphertext, fingerprintNonce: fingerprintNonce, senderFingerprint: senderFingerprint)
+
+            return OccultaBundle(version: version, secrecy: secrecy, ciphertext: ciphertext, fingerprintNonce: fingerprintNonce, senderFingerprint: senderFingerprint)
         }
-        
+
         debugPrint("Sealing message, using long-term identity key...")
 
         // ── Long-term fallback path (contactPrekey nil) ──────────────────
         // Caller explicitly chose this path because prekeys are exhausted.
-        return try self.fallback(message: message, recipientMaterial: recipientMaterial, fingerprintNonce: fingerprintNonce, senderFingerprint: senderFingerprint, quantumMaterial: quantumMaterial)
+        return try self.fallback(message: message, recipientMaterial: recipientMaterial, fingerprintNonce: fingerprintNonce, senderFingerprint: senderFingerprint, quantumMaterial: quantumMaterial, version: version)
     }
 }
 
@@ -133,7 +133,7 @@ extension Manager.Crypto {
 // MARK: - Private helpers
 
 extension Manager.Crypto {
-    private func fallback(message: Data, recipientMaterial: Data, fingerprintNonce: Data, senderFingerprint: Data, quantumMaterial: QuantumKeyMaterial?) throws -> OccultaBundle {
+    private func fallback(message: Data, recipientMaterial: Data, fingerprintNonce: Data, senderFingerprint: Data, quantumMaterial: QuantumKeyMaterial?, version: OccultaBundle.Version) throws -> OccultaBundle {
         guard
             let sessionKey = self.deriveSessionKey(using: recipientMaterial, quantumMaterial: quantumMaterial)
         else {
@@ -144,7 +144,7 @@ extension Manager.Crypto {
         let mode    = quantumMaterial != nil ? OccultaBundle.Mode.longTermFallback : .longTermNoPQ
         let secrecy = OccultaBundle.SecrecyContext(mode: mode, ephemeralPublicKey: Data(), prekeyID: nil)
         /// Adding `version` and `secrecy` to authenticate against tampering.
-        let aad = try OccultaBundle.computeAdditionalAuthentication(version: OccultaBundle.currentVersion, secrecy: secrecy)
+        let aad = try OccultaBundle.computeAdditionalAuthentication(version: version, secrecy: secrecy)
 
         guard
             let ciphertext = try AES.GCM.seal(message, using: sessionKey, nonce: AES.GCM.Nonce(), authenticating: aad).combined
@@ -152,7 +152,7 @@ extension Manager.Crypto {
             throw EncryptionError.keyDerivationFailed
         }
 
-        return OccultaBundle(version: OccultaBundle.currentVersion, secrecy: secrecy, ciphertext: ciphertext, fingerprintNonce:  fingerprintNonce, senderFingerprint: senderFingerprint)
+        return OccultaBundle(version: version, secrecy: secrecy, ciphertext: ciphertext, fingerprintNonce: fingerprintNonce, senderFingerprint: senderFingerprint)
     }
 }
 

--- a/Occulta/Features/Forward+Secrecy/OccultaBundle.swift
+++ b/Occulta/Features/Forward+Secrecy/OccultaBundle.swift
@@ -94,12 +94,45 @@ struct OccultaBundle: Codable {
         case v2
         /// Per-contact consumed prekey batches. `SecrecyContext` + version authenticated as AAD.
         case v3fs
+        /// Binary wire format — eliminates base64 inflation at all three serialisation layers.
+        /// First shipped in app version 1.8.2. See Docs/Features/Bundle/SPEC.md.
+        case v4
         /// A version string this build does not understand.
         /// Never written to the wire — only produced by `init(from:)` when an
         /// inbound bundle carries an unknown raw value. Decryption aborts
         /// before AAD computation; AAD would fail anyway since the original
         /// version string is lost.
         case unsupported
+
+        /// The minimum app version that can read this wire format.
+        /// `nil` means the case is not a real wire format (legacy, unsupported).
+        var minimumAppVersion: String? {
+            switch self {
+            case .v3fs: return "0.0.0"
+            case .v4:   return "1.8.2"
+            default:    return nil
+            }
+        }
+
+        /// The binary wire byte for this version. Used by WireHandle for encoding/decoding.
+        /// `nil` for cases that are JSON-only or not real wire formats.
+        var wireByte: UInt8? {
+            switch self {
+            case .v4: return 0x04
+            default:  return nil
+            }
+        }
+
+        /// All real wire versions in descending capability order.
+        private static let known: [Version] = [.v4, .v3fs]
+
+        /// The highest wire format version a contact running `appVersion` can decode.
+        static func max(forAppVersion appVersion: String) -> Version {
+            Self.known.first {
+                guard let min = $0.minimumAppVersion else { return false }
+                return appVersion.compare(min, options: .numeric) != .orderedAscending
+            } ?? .v3fs
+        }
 
         init(from decoder: Decoder) throws {
             let raw = try decoder.singleValueContainer().decode(String.self)
@@ -288,13 +321,19 @@ struct OccultaBundle: Codable {
         /// Owner → trustee direction only. Added in v1.7.0.
         let expectedShards: [UUID]?
 
+        /// Sender's app version string (e.g. `"1.8.2"`). Receivers derive the contact's
+        /// `maxBundleVersion` from this and store it encrypted on the contact record.
+        /// `nil` means the sender is on a build older than 1.8.2. Added in v1.8.2.
+        let appVersion: String?
+
         init(
             message: Data,
             prekeyBatch: PrekeySyncBatch? = nil,
             identityChallenge: IdentityChallengeEnvelope? = nil,
             shardOperations: [ShardOperation]? = nil,
             custodyManifest: [UUID]? = nil,
-            expectedShards: [UUID]? = nil
+            expectedShards: [UUID]? = nil,
+            appVersion: String? = nil
         ) {
             self.message           = message
             self.prekeyBatch       = prekeyBatch
@@ -302,6 +341,7 @@ struct OccultaBundle: Codable {
             self.shardOperations   = shardOperations
             self.custodyManifest   = custodyManifest
             self.expectedShards    = expectedShards
+            self.appVersion        = appVersion
         }
 
         /// A versioned batch of the sender's prekey public keys.
@@ -394,12 +434,21 @@ struct OccultaBundle: Codable {
 
     // MARK: - Serialisation
 
-    func encoded() throws -> Data {
-        try JSONEncoder().encode(self)
+    func encoded(version: Version = .v3fs) throws -> Data {
+        switch version {
+        case .v4:
+            return try WireHandle.encode(self)
+        default:
+            return try JSONEncoder().encode(self)
+        }
     }
 
     static func decoded(from data: Data) throws -> OccultaBundle {
-        try JSONDecoder().decode(OccultaBundle.self, from: data)
+        if data.prefix(WireHandle.magic.count).elementsEqual(WireHandle.magic) {
+            let parsed = try WireHandle.parse(data)
+            return try OccultaBundle(wireBundle: parsed)
+        }
+        return try JSONDecoder().decode(OccultaBundle.self, from: data)
     }
 
     // MARK: - AAD
@@ -442,5 +491,33 @@ struct OccultaBundle: Codable {
         case .longTermNoPQ:        return "Standard Encryption"
         case .unsupported:         return "Unsupported"
         }
+    }
+}
+
+// MARK: - WireHandle bridge
+
+extension OccultaBundle {
+    /// Reconstruct an `OccultaBundle` from a parsed binary outer envelope.
+    init(wireBundle b: WireHandle.Bundle) throws {
+        guard let version = WireHandle.byteToVersion(b.version) else {
+            throw BundleError.unsupportedVersion
+        }
+        guard let mode = WireHandle.byteToMode(b.mode) else {
+            throw BundleError.unsupportedMode
+        }
+        let prekeyID: String?
+        if let pid = b.prekeyID {
+            guard let s = String(data: pid, encoding: .utf8) else {
+                throw BundleError.unsupportedVersion
+            }
+            prekeyID = s
+        } else {
+            prekeyID = nil
+        }
+        self.version           = version
+        self.secrecy           = SecrecyContext(mode: mode, ephemeralPublicKey: b.ephemeralKey, prekeyID: prekeyID)
+        self.ciphertext        = b.ciphertext
+        self.fingerprintNonce  = b.fingerprintNonce
+        self.senderFingerprint = b.senderFingerprint
     }
 }

--- a/Occulta/Features/Forward+Secrecy/WireHandle.swift
+++ b/Occulta/Features/Forward+Secrecy/WireHandle.swift
@@ -1,0 +1,408 @@
+//
+//  WireHandle.swift
+//  Occulta
+//
+
+import CryptoKit
+import Foundation
+
+// MARK: - WireHandle
+
+/// Binary codec for the v4 bundle wire format. Purely a serialisation layer —
+/// the in-memory representation (`OccultaBundle`, `SealedPayload`, `Basket`)
+/// is unchanged. See Docs/Features/Bundle/SPEC.md for the full wire layout.
+///
+/// Each method maps 1:1 to a future Rust FFI call in `occulta-protocol`.
+struct WireHandle {
+
+    static let magic: [UInt8] = [0x4F, 0x43, 0x43, 0x42]  // "OCCB"
+
+    // MARK: - Outer Bundle
+
+    /// Parsed outer envelope. Does not contain decrypted content.
+    /// Use `fingerprintNonce` + `senderFingerprint` to identify the sender
+    /// before calling `open`.
+    struct Bundle {
+        let version: UInt8
+        let minReaderVersion: UInt8
+        let mode: UInt8
+        let flags: UInt16
+        let prekeyID: Data?          // nil or 36-byte UTF-8 UUID
+        let ephemeralKey: Data       // 65-byte P-256 key, or empty Data on longTerm paths
+        let fingerprintNonce: Data   // 16 bytes
+        let senderFingerprint: Data  // 32 bytes
+        let ciphertext: Data         // AES-GCM combined: nonce(12) || ct || tag(16)
+    }
+
+    // MARK: - Outer envelope: parse
+
+    /// Parse the binary outer envelope without decrypting.
+    /// Throws `BundleError.unsupportedVersion` if `min_reader_version` exceeds this build.
+    static func parse(_ data: Data) throws -> Bundle {
+        var r = Reader(data)
+
+        let magic4 = try r.read(4)
+        guard magic4.elementsEqual(magic) else { throw OccultaBundle.BundleError.unsupportedVersion }
+
+        let version          = try r.uint8()
+        let minReaderVersion = try r.uint8()
+        let mode             = try r.uint8()
+        let flags            = try r.uint16BE()
+        let hasPrekeyID      = try r.uint8() == 0x01
+        let prekeyIDBytes    = try r.read(36)
+        let ephemeralKeyRaw  = try r.read(65)
+        let fingerprintNonce = try r.read(16)
+        let senderFP         = try r.read(32)
+        let ctLen            = try r.uint64BE()
+        let ciphertext       = try r.read(Int(ctLen))
+
+        guard minReaderVersion <= Self.versionByte else {
+            throw OccultaBundle.BundleError.unsupportedVersion
+        }
+
+        let prekeyID = hasPrekeyID ? prekeyIDBytes : nil
+        // 65 zero bytes signals empty ephemeral key (longTerm paths).
+        // A real P-256 key always begins with 0x04 — all-zero is not a valid key.
+        let ephemeralKey = ephemeralKeyRaw.allSatisfy({ $0 == 0 }) ? Data() : ephemeralKeyRaw
+
+        return Bundle(
+            version:           version,
+            minReaderVersion:  minReaderVersion,
+            mode:              mode,
+            flags:             flags,
+            prekeyID:          prekeyID,
+            ephemeralKey:      ephemeralKey,
+            fingerprintNonce:  fingerprintNonce,
+            senderFingerprint: senderFP,
+            ciphertext:        ciphertext
+        )
+    }
+
+    // MARK: - Outer envelope: open
+
+    /// Compute AAD from the parsed bundle and AES-GCM decrypt.
+    /// The plaintext is a binary `SealedPayload` — pass it to `decode(payload:)`.
+    static func open(_ bundle: Bundle, using key: SymmetricKey) throws -> Data {
+        guard let mode = Self.byteToMode(bundle.mode) else {
+            throw OccultaBundle.BundleError.unsupportedMode
+        }
+        guard let version = Self.byteToVersion(bundle.version) else {
+            throw OccultaBundle.BundleError.unsupportedVersion
+        }
+
+        let prekeyIDString: String?
+        if let pid = bundle.prekeyID {
+            guard let s = String(data: pid, encoding: .utf8) else {
+                throw OccultaBundle.BundleError.unsupportedVersion
+            }
+            prekeyIDString = s
+        } else {
+            prekeyIDString = nil
+        }
+
+        let secrecy = OccultaBundle.SecrecyContext(
+            mode:               mode,
+            ephemeralPublicKey: bundle.ephemeralKey,
+            prekeyID:           prekeyIDString
+        )
+        let aad = try OccultaBundle.computeAdditionalAuthentication(version: version, secrecy: secrecy)
+        let box = try AES.GCM.SealedBox(combined: bundle.ciphertext)
+        return try AES.GCM.open(box, using: key, authenticating: aad)
+    }
+
+    // MARK: - Outer envelope: encode
+
+    /// Encode a fully constructed `OccultaBundle` as a binary outer envelope.
+    /// The bundle's `ciphertext` must already be the AES-GCM combined output.
+    static func encode(_ bundle: OccultaBundle) throws -> Data {
+        guard let vByte = Self._versionToByte[bundle.version] else {
+            throw OccultaBundle.BundleError.unsupportedVersion
+        }
+        guard let mByte = Self._modeToByte[bundle.secrecy.mode] else {
+            throw OccultaBundle.BundleError.unsupportedMode
+        }
+
+        var w = Writer()
+        w.bytes(magic)
+        w.uint8(vByte)              // version
+        w.uint8(vByte)              // min_reader_version = same as version
+        w.uint8(mByte)              // mode
+        w.uint16BE(0x0000)          // flags (reserved)
+
+        if let pid = bundle.secrecy.prekeyID,
+           let pidData = pid.data(using: .utf8), pidData.count == 36 {
+            w.uint8(0x01)
+            w.data(pidData)
+        } else {
+            w.uint8(0x00)
+            w.zeros(36)
+        }
+
+        let eph = bundle.secrecy.ephemeralPublicKey
+        if eph.isEmpty { w.zeros(65) } else { w.data(eph) }
+
+        w.data(bundle.fingerprintNonce)
+        w.data(bundle.senderFingerprint)
+        w.uint64BE(UInt64(bundle.ciphertext.count))
+        w.data(bundle.ciphertext)
+
+        return w.result
+    }
+
+    // MARK: - Payload: encode
+
+    /// Binary-encode a `SealedPayload`. This is the plaintext passed to AES.GCM.seal.
+    /// The `message` field (already binary Basket bytes) is written as raw bytes.
+    /// All other fields are written as a length-prefixed JSON block.
+    static func encode(payload: OccultaBundle.SealedPayload) throws -> Data {
+        let meta = PayloadMeta(
+            appVersion:        payload.appVersion,
+            prekeyBatch:       payload.prekeyBatch,
+            identityChallenge: payload.identityChallenge,
+            shardOperations:   payload.shardOperations,
+            custodyManifest:   payload.custodyManifest,
+            expectedShards:    payload.expectedShards
+        )
+        let metaJSON = try Self.sortedEncoder.encode(meta)
+
+        var w = Writer()
+        w.uint32BE(UInt32(metaJSON.count))
+        w.data(metaJSON)
+        w.uint64BE(UInt64(payload.message.count))
+        w.data(payload.message)
+        return w.result
+    }
+
+    // MARK: - Payload: decode
+
+    /// Decode binary `SealedPayload` bytes produced by `encode(payload:)`.
+    static func decode(payload data: Data) throws -> OccultaBundle.SealedPayload {
+        var r = Reader(data)
+
+        let metaLen  = Int(try r.uint32BE())
+        let metaJSON = try r.read(metaLen)
+        let msgLen   = Int(try r.uint64BE())
+        let message  = try r.read(msgLen)
+
+        let meta = try JSONDecoder().decode(PayloadMeta.self, from: metaJSON)
+
+        return OccultaBundle.SealedPayload(
+            message:           message,
+            prekeyBatch:       meta.prekeyBatch,
+            identityChallenge: meta.identityChallenge,
+            shardOperations:   meta.shardOperations,
+            custodyManifest:   meta.custodyManifest,
+            expectedShards:    meta.expectedShards,
+            appVersion:        meta.appVersion
+        )
+    }
+
+    // MARK: - Basket: encode
+
+    /// Binary-encode a `Basket`. The result becomes `SealedPayload.message`.
+    /// File content is written as raw bytes; all other metadata is JSON.
+    static func encode(basket: Basket) throws -> Data {
+        let meta = BasketMeta(id: basket.id, date: basket.date, owner: basket.owner)
+        let metaJSON = try Self.sortedEncoder.encode(meta)
+
+        var w = Writer()
+        w.uint32BE(UInt32(metaJSON.count))
+        w.data(metaJSON)
+        w.uint32BE(UInt32(basket.files.count))
+
+        for file in basket.files {
+            let fileMeta = FileMeta(id: file.id, format: file.format, date: file.date)
+            let fileMetaJSON = try Self.sortedEncoder.encode(fileMeta)
+
+            w.uint32BE(UInt32(fileMetaJSON.count))
+            w.data(fileMetaJSON)
+
+            let content = file.content ?? Data()
+            w.uint64BE(UInt64(content.count))
+            w.data(content)
+        }
+
+        return w.result
+    }
+
+    // MARK: - Basket: decode
+
+    /// Decode binary Basket bytes produced by `encode(basket:)`.
+    static func decode(basket data: Data) throws -> Basket {
+        var r = Reader(data)
+
+        let metaLen   = Int(try r.uint32BE())
+        let metaJSON  = try r.read(metaLen)
+        let fileCount = Int(try r.uint32BE())
+
+        let meta = try JSONDecoder().decode(BasketMeta.self, from: metaJSON)
+
+        var files: [File] = []
+        for _ in 0..<fileCount {
+            let fMetaLen  = Int(try r.uint32BE())
+            let fMetaJSON = try r.read(fMetaLen)
+            let ctLen     = Int(try r.uint64BE())
+            let content   = ctLen > 0 ? try r.read(ctLen) : nil
+
+            let fMeta = try JSONDecoder().decode(FileMeta.self, from: fMetaJSON)
+            files.append(File(id: fMeta.id, content: content, format: fMeta.format, date: fMeta.date))
+        }
+
+        return Basket(id: meta.id, files: files, date: meta.date, owner: meta.owner)
+    }
+
+    // MARK: - Version / mode byte tables
+
+    static let versionByte: UInt8 = 0x04
+
+    static func byteToVersion(_ b: UInt8) -> OccultaBundle.Version? { Self._byteToVersion[b] }
+    static func byteToMode(_ b: UInt8)    -> OccultaBundle.Mode?    { Self._byteToMode[b] }
+
+    private static let _versionToByte: [OccultaBundle.Version: UInt8] = [.v4: 0x04]
+    private static let _byteToVersion: [UInt8: OccultaBundle.Version] = [0x04: .v4]
+
+    private static let _modeToByte: [OccultaBundle.Mode: UInt8] = [
+        .forwardSecret:     0x01,
+        .forwardSecretNoPQ: 0x02,
+        .longTermFallback:  0x03,
+        .longTermNoPQ:      0x04,
+    ]
+    private static let _byteToMode: [UInt8: OccultaBundle.Mode] = [
+        0x01: .forwardSecret,
+        0x02: .forwardSecretNoPQ,
+        0x03: .longTermFallback,
+        0x04: .longTermNoPQ,
+    ]
+
+    private static let sortedEncoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = .sortedKeys
+        return e
+    }()
+}
+
+// MARK: - Private metadata Codable structs
+// Nil fields are omitted (not encoded as null) per spec §4.2.1 and §4.3.1.
+
+private struct PayloadMeta: Codable {
+    var appVersion: String?
+    var prekeyBatch: OccultaBundle.SealedPayload.PrekeySyncBatch?
+    var identityChallenge: IdentityChallengeEnvelope?
+    var shardOperations: [OccultaBundle.ShardOperation]?
+    var custodyManifest: [UUID]?
+    var expectedShards: [UUID]?
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encodeIfPresent(self.appVersion,        forKey: .appVersion)
+        try c.encodeIfPresent(self.prekeyBatch,       forKey: .prekeyBatch)
+        try c.encodeIfPresent(self.identityChallenge, forKey: .identityChallenge)
+        try c.encodeIfPresent(self.shardOperations,   forKey: .shardOperations)
+        try c.encodeIfPresent(self.custodyManifest,   forKey: .custodyManifest)
+        try c.encodeIfPresent(self.expectedShards,    forKey: .expectedShards)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case appVersion, prekeyBatch, identityChallenge, shardOperations, custodyManifest, expectedShards
+    }
+}
+
+private struct BasketMeta: Codable {
+    var id: UUID
+    var date: Date?
+    var owner: Data?
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(self.id,              forKey: .id)
+        try c.encodeIfPresent(self.date,   forKey: .date)
+        try c.encodeIfPresent(self.owner,  forKey: .owner)
+    }
+
+    enum CodingKeys: String, CodingKey { case id, date, owner }
+}
+
+private struct FileMeta: Codable {
+    var id: UUID
+    var format: File.Format?
+    var date: Date?
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(self.id,              forKey: .id)
+        try c.encodeIfPresent(self.format, forKey: .format)
+        try c.encodeIfPresent(self.date,   forKey: .date)
+    }
+
+    enum CodingKeys: String, CodingKey { case id, format, date }
+}
+
+// MARK: - Reader (sequential big-endian byte reader)
+
+private struct Reader {
+    private let data: Data
+    private var offset: Int
+
+    init(_ data: Data) {
+        self.data   = data
+        self.offset = data.startIndex
+    }
+
+    mutating func read(_ count: Int) throws -> Data {
+        let end = offset + count
+        guard end <= data.endIndex else { throw OccultaBundle.BundleError.unsupportedVersion }
+        defer { offset = end }
+        return data[offset..<end]
+    }
+
+    mutating func uint8() throws -> UInt8 {
+        let b = try read(1)
+        return b[b.startIndex]
+    }
+
+    mutating func uint16BE() throws -> UInt16 {
+        let b = Array(try read(2))
+        return UInt16(b[0]) << 8 | UInt16(b[1])
+    }
+
+    mutating func uint32BE() throws -> UInt32 {
+        let b = Array(try read(4))
+        return UInt32(b[0]) << 24 | UInt32(b[1]) << 16 | UInt32(b[2]) << 8 | UInt32(b[3])
+    }
+
+    mutating func uint64BE() throws -> UInt64 {
+        let b = Array(try read(8))
+        var v: UInt64 = 0
+        for byte in b { v = v << 8 | UInt64(byte) }
+        return v
+    }
+}
+
+// MARK: - Writer (sequential big-endian byte writer)
+
+private struct Writer {
+    private(set) var result = Data()
+
+    mutating func bytes(_ v: [UInt8])  { result.append(contentsOf: v) }
+    mutating func data(_ v: Data)      { result.append(v) }
+    mutating func zeros(_ count: Int)  { result.append(contentsOf: [UInt8](repeating: 0, count: count)) }
+    mutating func uint8(_ v: UInt8)    { result.append(v) }
+
+    mutating func uint16BE(_ v: UInt16) {
+        result.append(UInt8(v >> 8))
+        result.append(UInt8(v & 0xFF))
+    }
+
+    mutating func uint32BE(_ v: UInt32) {
+        result.append(UInt8((v >> 24) & 0xFF))
+        result.append(UInt8((v >> 16) & 0xFF))
+        result.append(UInt8((v >>  8) & 0xFF))
+        result.append(UInt8( v        & 0xFF))
+    }
+
+    mutating func uint64BE(_ v: UInt64) {
+        for shift in stride(from: 56, through: 0, by: -8) {
+            result.append(UInt8((v >> shift) & 0xFF))
+        }
+    }
+}

--- a/Occulta/Info.plist
+++ b/Occulta/Info.plist
@@ -57,6 +57,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Used to attach photos and videos to encrypted messages.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_peer-data-ex._tcp</string>

--- a/Occulta/Services/Attachment+Manager.swift
+++ b/Occulta/Services/Attachment+Manager.swift
@@ -1,0 +1,340 @@
+//
+//  Attachment+Manager.swift
+//  Occulta
+//
+
+import Foundation
+import CryptoKit
+import AVFoundation
+import UniformTypeIdentifiers
+import UIKit
+
+// MARK: - AttachmentManager
+
+/// Encrypts and decrypts file attachments stored on disk.
+///
+/// Initialized once per contact session with that contact's long-term shared
+/// secret. All per-file keys are derived internally via HKDF — callers never
+/// see key material.
+final class AttachmentManager: Sendable {
+    private let contactKey: SymmetricKey
+
+    init(contactKey: SymmetricKey) {
+        self.contactKey = contactKey
+    }
+
+    // MARK: Write
+
+    func encrypt(_ data: Data, to url: URL) throws {
+        try Encryptor.write(data, contactKey: self.contactKey, to: url)
+    }
+
+    // MARK: Image
+
+    func image(at url: URL) async throws -> UIImage {
+        let key = self.contactKey
+        return try await Task.detached(priority: .userInitiated) {
+            let data = try Decryptor.all(at: url, contactKey: key)
+            guard let image = UIImage(data: data) else { throw AttachmentError.invalidImageData }
+            return image
+        }.value
+    }
+
+    // MARK: Video
+
+    /// Returns an `AVPlayer` whose I/O is served by an encrypted resource loader.
+    /// The player decrypts only the chunks AVFoundation requests — no plaintext
+    /// file is ever written.
+    func player(for url: URL) -> AVPlayer {
+        let loader = ResourceLoader(fileURL: url, contactKey: self.contactKey)
+        let asset  = AVURLAsset(url: Self.occattURL(for: url))
+        asset.resourceLoader.setDelegate(loader, queue: .global(qos: .userInitiated))
+        let player = AVPlayer(playerItem: AVPlayerItem(asset: asset))
+        // AVFoundation holds a weak reference to the delegate — retain it on the player.
+        objc_setAssociatedObject(player, &AssociatedKeys.loader, loader, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return player
+    }
+
+    // MARK: Share / export
+
+    /// Returns a `UIActivityItemProvider` that decrypts the file on a background
+    /// thread and hands the plaintext `Data` to the share sheet.
+    func shareProvider(at url: URL, filename: String, contentType: UTType) -> UIActivityItemProvider {
+        ShareProvider(fileURL: url, filename: filename, contentType: contentType, contactKey: self.contactKey)
+    }
+
+    // MARK: Private
+
+    private static func occattURL(for fileURL: URL) -> URL {
+        URL(string: "occatt://\(fileURL.lastPathComponent)")!
+    }
+}
+
+// MARK: - Header (101 bytes)
+//
+//  Offset  Size  Field
+//   0       4    magic "OATT"
+//   4       1    version 0x01
+//   5       4    chunk_size  (UInt32 big-endian)
+//   9       8    chunk_count (UInt64 big-endian)
+//  17       8    plaintext_size (UInt64 big-endian)
+//  25      12    base_nonce (random)
+//  37      32    key_salt   (random, per-file HKDF input)
+//  69      32    header_mac (HMAC-SHA256 of bytes 0..<69)
+
+private struct Header {
+    static let magic:     [UInt8] = Array("OATT".utf8)
+    static let version:   UInt8   = 0x01
+    static let byteCount: Int     = 101
+
+    let chunkSize:     Int
+    let chunkCount:    Int
+    let plaintextSize: Int
+    let baseNonce:     AES.GCM.Nonce
+    let keySalt:       Data
+}
+
+// MARK: - Encryptor
+
+private enum Encryptor {
+    static let chunkSize = 262_144 // 256 KB
+
+    static func write(_ plaintext: Data, contactKey: SymmetricKey, to url: URL) throws {
+        let baseNonce = AES.GCM.Nonce()
+        let keySalt   = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+        let fileKey   = derivedFileKey(contactKey: contactKey, salt: keySalt)
+        let total     = plaintext.count
+        let chunks    = max(1, (total + chunkSize - 1) / chunkSize)
+
+        var header = Data()
+        header.append(contentsOf: Header.magic)
+        header.append(Header.version)
+        header.append(contentsOf: UInt32(chunkSize).bigEndianData)
+        header.append(contentsOf: UInt64(chunks).bigEndianData)
+        header.append(contentsOf: UInt64(total).bigEndianData)
+        header.append(contentsOf: baseNonce.dataRepresentation)
+        header.append(contentsOf: keySalt)
+        header.append(contentsOf: HMAC<SHA256>.authenticationCode(for: header, using: fileKey))
+
+        var output = header
+        for i in 0..<chunks {
+            let start = i * chunkSize
+            let end   = min(start + chunkSize, total)
+            let box   = try AES.GCM.seal(
+                total > 0 ? plaintext[start..<end] : Data(),
+                using: fileKey,
+                nonce: derivedNonce(base: baseNonce, index: i)
+            )
+            output.append(contentsOf: box.ciphertext)
+            output.append(contentsOf: box.tag)
+        }
+
+        try output.writeProtected(to: url)
+    }
+}
+
+// MARK: - Decryptor
+
+private enum Decryptor {
+    static func all(at url: URL, contactKey: SymmetricKey) throws -> Data {
+        let h = try header(at: url, contactKey: contactKey)
+        guard h.plaintextSize > 0 else { return Data() }
+        return try range(at: url, offset: 0, length: h.plaintextSize, contactKey: contactKey)
+    }
+
+    static func range(at url: URL, offset: Int, length: Int, contactKey: SymmetricKey) throws -> Data {
+        guard length > 0 else { return Data() }
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        guard let headerBytes = try handle.read(upToCount: Header.byteCount),
+              headerBytes.count == Header.byteCount
+        else { throw AttachmentError.invalidHeader }
+
+        let h       = try parseHeader(headerBytes, contactKey: contactKey)
+        let fileKey = derivedFileKey(contactKey: contactKey, salt: h.keySalt)
+        let clampedLength = min(length, h.plaintextSize - offset)
+
+        let first = offset / h.chunkSize
+        let last  = min((offset + clampedLength - 1) / h.chunkSize, h.chunkCount - 1)
+
+        var plaintext = Data()
+        for i in first...last {
+            let isLast         = i == h.chunkCount - 1
+            let ciphertextSize = isLast ? h.plaintextSize - i * h.chunkSize : h.chunkSize
+            try handle.seek(toOffset: UInt64(Header.byteCount + i * (h.chunkSize + 16)))
+            guard let raw = try handle.read(upToCount: ciphertextSize + 16),
+                  raw.count == ciphertextSize + 16
+            else { throw AttachmentError.truncated }
+
+            let box = try AES.GCM.SealedBox(
+                nonce:      derivedNonce(base: h.baseNonce, index: i),
+                ciphertext: raw.prefix(ciphertextSize),
+                tag:        raw.suffix(16)
+            )
+            plaintext.append(contentsOf: try AES.GCM.open(box, using: fileKey))
+        }
+
+        let trimStart = offset - first * h.chunkSize
+        return Data(plaintext[trimStart..<(trimStart + clampedLength)])
+    }
+
+    static func header(at url: URL, contactKey: SymmetricKey) throws -> Header {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        guard let bytes = try handle.read(upToCount: Header.byteCount),
+              bytes.count == Header.byteCount
+        else { throw AttachmentError.invalidHeader }
+        return try parseHeader(bytes, contactKey: contactKey)
+    }
+
+    private static func parseHeader(_ bytes: Data, contactKey: SymmetricKey) throws -> Header {
+        guard bytes.prefix(4).elementsEqual(Header.magic) else { throw AttachmentError.invalidHeader }
+        guard bytes[4] == Header.version                  else { throw AttachmentError.unsupportedVersion }
+
+        let chunkSize     = Int(UInt32(bigEndianBytes: bytes[5..<9]))
+        let chunkCount    = Int(UInt64(bigEndianBytes: bytes[9..<17]))
+        let plaintextSize = Int(UInt64(bigEndianBytes: bytes[17..<25]))
+        let nonceData     = bytes[25..<37]
+        let keySalt       = Data(bytes[37..<69])
+        let storedMac     = Data(bytes[69..<101])
+
+        let fileKey     = derivedFileKey(contactKey: contactKey, salt: keySalt)
+        let computedMac = Data(HMAC<SHA256>.authenticationCode(for: bytes[..<69], using: fileKey))
+        guard computedMac == storedMac else { throw AttachmentError.headerMACFailed }
+
+        return Header(
+            chunkSize:     chunkSize,
+            chunkCount:    chunkCount,
+            plaintextSize: plaintextSize,
+            baseNonce:     try AES.GCM.Nonce(data: nonceData),
+            keySalt:       keySalt
+        )
+    }
+}
+
+// MARK: - Helpers
+
+private func derivedFileKey(contactKey: SymmetricKey, salt: some DataProtocol) -> SymmetricKey {
+    HKDF<SHA256>.deriveKey(
+        inputKeyMaterial: contactKey,
+        salt:             salt,
+        info:             SaltInfo.kFileKeyInfo,
+        outputByteCount:  32
+    )
+}
+
+private func derivedNonce(base: AES.GCM.Nonce, index: Int) throws -> AES.GCM.Nonce {
+    var bytes = base.withUnsafeBytes { Array($0) }
+    let idx   = withUnsafeBytes(of: UInt64(index).bigEndian) { Array($0) }
+    for j in 0..<8 { bytes[4 + j] ^= idx[j] }
+    return try AES.GCM.Nonce(data: Data(bytes))
+}
+
+// MARK: - Resource Loader (in-app video playback)
+
+private final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
+    private let fileURL:    URL
+    private let contactKey: SymmetricKey
+
+    init(fileURL: URL, contactKey: SymmetricKey) {
+        self.fileURL    = fileURL
+        self.contactKey = contactKey
+    }
+
+    func resourceLoader(
+        _ resourceLoader: AVAssetResourceLoader,
+        shouldWaitForLoadingOfRequestedResource request: AVAssetResourceLoadingRequest
+    ) -> Bool {
+        if let info = request.contentInformationRequest,
+           let h    = try? Decryptor.header(at: self.fileURL, contactKey: self.contactKey) {
+            info.contentType                = UTType.movie.identifier
+            info.contentLength              = Int64(h.plaintextSize)
+            info.isByteRangeAccessSupported = true
+        }
+        if let data = request.dataRequest {
+            let offset = Int(data.requestedOffset)
+            let length = data.requestedLength
+            do {
+                let plain = try Decryptor.range(at: self.fileURL, offset: offset, length: length, contactKey: self.contactKey)
+                data.respond(with: plain)
+                request.finishLoading()
+            } catch {
+                request.finishLoading(with: error)
+            }
+        }
+        return true
+    }
+}
+
+// MARK: - Share Provider
+
+private final class ShareProvider: UIActivityItemProvider {
+    private let fileURL:     URL
+    private let filename:    String
+    private let contentType: UTType
+    private let contactKey:  SymmetricKey
+
+    init(fileURL: URL, filename: String, contentType: UTType, contactKey: SymmetricKey) {
+        self.fileURL     = fileURL
+        self.filename    = filename
+        self.contentType = contentType
+        self.contactKey  = contactKey
+        super.init(placeholderItem: Data())
+    }
+
+    // Called on a background thread by UIActivityViewController.
+    override var item: Any {
+        (try? Decryptor.all(at: self.fileURL, contactKey: self.contactKey)) ?? Data()
+    }
+
+    override func activityViewController(
+        _ ac: UIActivityViewController,
+        subjectForActivityType type: UIActivity.ActivityType?
+    ) -> String { self.filename }
+
+    override func activityViewController(
+        _ ac: UIActivityViewController,
+        dataTypeIdentifierForActivityType type: UIActivity.ActivityType?
+    ) -> String { self.contentType.identifier }
+}
+
+// MARK: - Errors
+
+enum AttachmentError: Error {
+    case invalidHeader
+    case unsupportedVersion
+    case headerMACFailed
+    case truncated
+    case invalidImageData
+}
+
+// MARK: - Associated object key
+
+private enum AssociatedKeys {
+    static var loader: UInt8 = 0
+}
+
+// MARK: - Encoding helpers
+
+private extension UInt32 {
+    var bigEndianData: Data { withUnsafeBytes(of: self.bigEndian) { Data($0) } }
+    init(bigEndianBytes bytes: some DataProtocol) {
+        var v: UInt32 = 0
+        _ = withUnsafeMutableBytes(of: &v) { ptr in bytes.copyBytes(to: ptr) }
+        self = UInt32(bigEndian: v)
+    }
+}
+
+private extension UInt64 {
+    var bigEndianData: Data { withUnsafeBytes(of: self.bigEndian) { Data($0) } }
+    init(bigEndianBytes bytes: some DataProtocol) {
+        var v: UInt64 = 0
+        _ = withUnsafeMutableBytes(of: &v) { ptr in bytes.copyBytes(to: ptr) }
+        self = UInt64(bigEndian: v)
+    }
+}
+
+private extension AES.GCM.Nonce {
+    var dataRepresentation: Data { self.withUnsafeBytes { Data($0) } }
+}

--- a/Occulta/Services/Attachment+Manager.swift
+++ b/Occulta/Services/Attachment+Manager.swift
@@ -30,6 +30,10 @@ final class AttachmentManager: Sendable {
         try Encryptor.write(data, contactKey: self.contactKey, to: url)
     }
 
+    func streamingEncryptor(to url: URL) throws -> StreamingEncryptor {
+        try StreamingEncryptor(url: url, contactKey: self.contactKey)
+    }
+
     nonisolated func encryptWithProgress(_ data: Data, to url: URL) -> AsyncThrowingStream<Double, Error> {
         let key = self.contactKey
         
@@ -108,10 +112,16 @@ final class AttachmentManager: Sendable {
     /// The player decrypts only the chunks AVFoundation requests — no plaintext
     /// file is ever written.
     func player(for url: URL) -> AVPlayer {
-        let loader = ResourceLoader(fileURL: url, contactKey: self.contactKey)
+        guard let loader = ResourceLoader(fileURL: url, contactKey: self.contactKey) else {
+            return AVPlayer()
+        }
         let asset  = AVURLAsset(url: Self.occattURL(for: url))
         asset.resourceLoader.setDelegate(loader, queue: .global(qos: .userInitiated))
-        let player = AVPlayer(playerItem: AVPlayerItem(asset: asset))
+        let item = AVPlayerItem(asset: asset)
+        // Limit pre-buffering — content is local so stalling is not a concern.
+        item.preferredForwardBufferDuration = 2
+        let player = AVPlayer(playerItem: item)
+        player.automaticallyWaitsToMinimizeStalling = false
         // AVFoundation holds a weak reference to the delegate — retain it on the player.
         objc_setAssociatedObject(player, &AssociatedKeys.loader, loader, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return player
@@ -281,6 +291,88 @@ private enum Decryptor {
     }
 }
 
+// MARK: - StreamingEncryptor
+
+final class StreamingEncryptor: @unchecked Sendable {
+    private let handle:    FileHandle
+    private let fileKey:   SymmetricKey
+    private let baseNonce: AES.GCM.Nonce
+    private let keySalt:   Data
+    private let chunkSize: Int
+    private var index:     Int  = 0
+    private var buffer:    Data = Data()
+
+    private(set) var totalBytes: Int = 0
+
+    init(url: URL, contactKey: SymmetricKey) throws {
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        
+        self.handle    = try FileHandle(forWritingTo: url)
+        // Bypass the page cache for all writes — prevents 2GB of dirty pages
+        // accumulating in RAM during large video encryption.
+        let result = fcntl(self.handle.fileDescriptor, F_NOCACHE, 1)
+        
+        #if DEBUG
+        debugPrint("No cache setting result was \(result)")
+        #endif
+        
+        self.chunkSize = Encryptor.chunkSize
+        self.keySalt   = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+        self.baseNonce = AES.GCM.Nonce()
+        self.fileKey   = derivedFileKey(contactKey: contactKey, salt: self.keySalt)
+        // Reserve space for header — finalize() overwrites it
+        try self.handle.write(contentsOf: Data(count: Header.byteCount))
+    }
+
+    func append(_ incoming: Data) throws {
+        self.totalBytes += incoming.count
+        var offset = 0
+        while offset < incoming.count {
+            let take = min(self.chunkSize - self.buffer.count, incoming.count - offset)
+            self.buffer.append(contentsOf: incoming[offset..<(offset + take)])
+            offset += take
+            if self.buffer.count == self.chunkSize {
+                try self.flush(self.buffer)
+                self.buffer.removeAll(keepingCapacity: true)
+            }
+        }
+    }
+
+    func finalize() throws {
+        // Only flush remaining bytes; skip if input was an exact multiple of chunkSize
+        if !self.buffer.isEmpty || self.index == 0 {
+            try self.flush(self.buffer)
+        }
+        self.buffer.removeAll()
+        try self.handle.synchronize()
+
+        var hdr = Data()
+        hdr.append(contentsOf: Header.magic)
+        hdr.append(Header.version)
+        hdr.append(contentsOf: UInt32(self.chunkSize).bigEndianData)
+        hdr.append(contentsOf: UInt64(self.index).bigEndianData)
+        hdr.append(contentsOf: UInt64(self.totalBytes).bigEndianData)
+        hdr.append(contentsOf: self.baseNonce.dataRepresentation)
+        hdr.append(contentsOf: self.keySalt)
+        hdr.append(contentsOf: HMAC<SHA256>.authenticationCode(for: hdr, using: self.fileKey))
+
+        try self.handle.seek(toOffset: 0)
+        try self.handle.write(contentsOf: hdr)
+        try self.handle.close()
+    }
+
+    private func flush(_ plaintext: Data) throws {
+        let box = try AES.GCM.seal(
+            plaintext,
+            using: self.fileKey,
+            nonce: derivedNonce(base: self.baseNonce, index: self.index)
+        )
+        try self.handle.write(contentsOf: box.ciphertext)
+        try self.handle.write(contentsOf: box.tag)
+        self.index += 1
+    }
+}
+
 // MARK: - Helpers
 
 nonisolated private func derivedFileKey(contactKey: SymmetricKey, salt: some DataProtocol) -> SymmetricKey {
@@ -302,12 +394,17 @@ nonisolated private func derivedNonce(base: AES.GCM.Nonce, index: Int) throws ->
 // MARK: - Resource Loader (in-app video playback)
 
 private final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
-    private let fileURL:    URL
-    private let contactKey: SymmetricKey
+    private let fileURL: URL
+    private let header:  Header
+    private let fileKey: SymmetricKey
 
-    init(fileURL: URL, contactKey: SymmetricKey) {
-        self.fileURL    = fileURL
-        self.contactKey = contactKey
+    // Parses and HMAC-validates the header once at init. Returns nil if the
+    // file is unreadable or the key is wrong — AVFoundation will show a blank player.
+    init?(fileURL: URL, contactKey: SymmetricKey) {
+        guard let h = try? Decryptor.header(at: fileURL, contactKey: contactKey) else { return nil }
+        self.fileURL = fileURL
+        self.header  = h
+        self.fileKey = derivedFileKey(contactKey: contactKey, salt: h.keySalt)
     }
 
     func resourceLoader(
@@ -315,32 +412,65 @@ private final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
         shouldWaitForLoadingOfRequestedResource request: AVAssetResourceLoadingRequest
     ) -> Bool {
         if let info = request.contentInformationRequest {
-            guard let h = try? Decryptor.header(at: self.fileURL, contactKey: self.contactKey) else {
-                request.finishLoading(with: AttachmentError.invalidHeader)
-                return true
-            }
             let uti = UTType(filenameExtension: self.fileURL.pathExtension)?.identifier
                    ?? UTType.movie.identifier
             info.contentType                = uti
-            info.contentLength              = Int64(h.plaintextSize)
+            info.contentLength              = Int64(self.header.plaintextSize)
             info.isByteRangeAccessSupported = true
             if request.dataRequest == nil {
                 request.finishLoading()
                 return true
             }
         }
-        if let data = request.dataRequest {
-            let offset = Int(data.requestedOffset)
-            let length = data.requestedLength
+        if let dataReq = request.dataRequest {
+            var cursor = Int(dataReq.currentOffset)
+            let end    = Int(dataReq.requestedOffset) + dataReq.requestedLength
             do {
-                let plain = try Decryptor.range(at: self.fileURL, offset: offset, length: length, contactKey: self.contactKey)
-                data.respond(with: plain)
+                // One FileHandle per AVFoundation request, shared across all chunks in
+                // that request — avoids a file open/close per 256KB chunk.
+                let handle = try FileHandle(forReadingFrom: self.fileURL)
+                defer { try? handle.close() }
+                while cursor < end {
+                    let length = min(self.header.chunkSize, end - cursor)
+                    let chunk  = try self.decryptChunk(at: cursor, length: length, using: handle)
+                    dataReq.respond(with: chunk)
+                    cursor += chunk.count
+                    if chunk.count < length { break }
+                }
                 request.finishLoading()
             } catch {
                 request.finishLoading(with: error)
             }
         }
         return true
+    }
+
+    private func decryptChunk(at offset: Int, length: Int, using handle: FileHandle) throws -> Data {
+        let h             = self.header
+        let clampedLength = min(length, h.plaintextSize - offset)
+        guard clampedLength > 0 else { return Data() }
+
+        let first = offset / h.chunkSize
+        let last  = min((offset + clampedLength - 1) / h.chunkSize, h.chunkCount - 1)
+
+        var plaintext = Data()
+        for i in first...last {
+            let isLast         = i == h.chunkCount - 1
+            let ciphertextSize = isLast ? h.plaintextSize - i * h.chunkSize : h.chunkSize
+            try handle.seek(toOffset: UInt64(Header.byteCount + i * (h.chunkSize + 16)))
+            guard let raw = try handle.read(upToCount: ciphertextSize + 16),
+                  raw.count == ciphertextSize + 16
+            else { throw AttachmentError.truncated }
+            let box = try AES.GCM.SealedBox(
+                nonce:      derivedNonce(base: h.baseNonce, index: i),
+                ciphertext: raw.prefix(ciphertextSize),
+                tag:        raw.suffix(16)
+            )
+            plaintext.append(contentsOf: try AES.GCM.open(box, using: self.fileKey))
+        }
+
+        let trimStart = offset - first * h.chunkSize
+        return Data(plaintext[trimStart..<(trimStart + clampedLength)])
     }
 }
 

--- a/Occulta/Services/Attachment+Manager.swift
+++ b/Occulta/Services/Attachment+Manager.swift
@@ -6,6 +6,7 @@
 import Foundation
 import CryptoKit
 import AVFoundation
+import ImageIO
 import UniformTypeIdentifiers
 import UIKit
 
@@ -25,7 +26,7 @@ final class AttachmentManager: Sendable {
 
     // MARK: Write
 
-    func encrypt(_ data: Data, to url: URL) throws {
+    nonisolated func encrypt(_ data: Data, to url: URL) throws {
         try Encryptor.write(data, contactKey: self.contactKey, to: url)
     }
 
@@ -33,10 +34,20 @@ final class AttachmentManager: Sendable {
 
     func image(at url: URL) async throws -> UIImage {
         let key = self.contactKey
+
         return try await Task.detached(priority: .userInitiated) {
-            let data = try Decryptor.all(at: url, contactKey: key)
-            guard let image = UIImage(data: data) else { throw AttachmentError.invalidImageData }
-            return image
+            let data   = try Decryptor.all(at: url, contactKey: key)
+            let source = CGImageSourceCreateWithData(data as CFData, nil)
+
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceThumbnailMaxPixelSize:          960,
+                kCGImageSourceCreateThumbnailWithTransform:   true
+            ]
+            guard let source,
+                  let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+            else { throw AttachmentError.invalidImageData }
+            return UIImage(cgImage: cgImage)
         }.value
     }
 
@@ -83,9 +94,9 @@ final class AttachmentManager: Sendable {
 //  69      32    header_mac (HMAC-SHA256 of bytes 0..<69)
 
 private struct Header {
-    static let magic:     [UInt8] = Array("OATT".utf8)
-    static let version:   UInt8   = 0x01
-    static let byteCount: Int     = 101
+    nonisolated static let magic:     [UInt8] = Array("OATT".utf8)
+    nonisolated static let version:   UInt8   = 0x01
+    nonisolated static let byteCount: Int     = 101
 
     let chunkSize:     Int
     let chunkCount:    Int
@@ -97,9 +108,9 @@ private struct Header {
 // MARK: - Encryptor
 
 private enum Encryptor {
-    static let chunkSize = 262_144 // 256 KB
+    nonisolated static let chunkSize = 262_144 // 256 KB
 
-    static func write(_ plaintext: Data, contactKey: SymmetricKey, to url: URL) throws {
+    nonisolated static func write(_ plaintext: Data, contactKey: SymmetricKey, to url: URL) throws {
         let baseNonce = AES.GCM.Nonce()
         let keySalt   = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
         let fileKey   = derivedFileKey(contactKey: contactKey, salt: keySalt)
@@ -136,13 +147,13 @@ private enum Encryptor {
 // MARK: - Decryptor
 
 private enum Decryptor {
-    static func all(at url: URL, contactKey: SymmetricKey) throws -> Data {
+    nonisolated static func all(at url: URL, contactKey: SymmetricKey) throws -> Data {
         let h = try header(at: url, contactKey: contactKey)
         guard h.plaintextSize > 0 else { return Data() }
         return try range(at: url, offset: 0, length: h.plaintextSize, contactKey: contactKey)
     }
 
-    static func range(at url: URL, offset: Int, length: Int, contactKey: SymmetricKey) throws -> Data {
+    nonisolated static func range(at url: URL, offset: Int, length: Int, contactKey: SymmetricKey) throws -> Data {
         guard length > 0 else { return Data() }
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
@@ -151,8 +162,8 @@ private enum Decryptor {
               headerBytes.count == Header.byteCount
         else { throw AttachmentError.invalidHeader }
 
-        let h       = try parseHeader(headerBytes, contactKey: contactKey)
-        let fileKey = derivedFileKey(contactKey: contactKey, salt: h.keySalt)
+        let h             = try parseHeader(headerBytes, contactKey: contactKey)
+        let fileKey       = derivedFileKey(contactKey: contactKey, salt: h.keySalt)
         let clampedLength = min(length, h.plaintextSize - offset)
 
         let first = offset / h.chunkSize
@@ -179,7 +190,7 @@ private enum Decryptor {
         return Data(plaintext[trimStart..<(trimStart + clampedLength)])
     }
 
-    static func header(at url: URL, contactKey: SymmetricKey) throws -> Header {
+    nonisolated static func header(at url: URL, contactKey: SymmetricKey) throws -> Header {
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
         guard let bytes = try handle.read(upToCount: Header.byteCount),
@@ -188,7 +199,7 @@ private enum Decryptor {
         return try parseHeader(bytes, contactKey: contactKey)
     }
 
-    private static func parseHeader(_ bytes: Data, contactKey: SymmetricKey) throws -> Header {
+    private nonisolated static func parseHeader(_ bytes: Data, contactKey: SymmetricKey) throws -> Header {
         guard bytes.prefix(4).elementsEqual(Header.magic) else { throw AttachmentError.invalidHeader }
         guard bytes[4] == Header.version                  else { throw AttachmentError.unsupportedVersion }
 
@@ -215,7 +226,7 @@ private enum Decryptor {
 
 // MARK: - Helpers
 
-private func derivedFileKey(contactKey: SymmetricKey, salt: some DataProtocol) -> SymmetricKey {
+nonisolated private func derivedFileKey(contactKey: SymmetricKey, salt: some DataProtocol) -> SymmetricKey {
     HKDF<SHA256>.deriveKey(
         inputKeyMaterial: contactKey,
         salt:             salt,
@@ -224,7 +235,7 @@ private func derivedFileKey(contactKey: SymmetricKey, salt: some DataProtocol) -
     )
 }
 
-private func derivedNonce(base: AES.GCM.Nonce, index: Int) throws -> AES.GCM.Nonce {
+nonisolated private func derivedNonce(base: AES.GCM.Nonce, index: Int) throws -> AES.GCM.Nonce {
     var bytes = base.withUnsafeBytes { Array($0) }
     let idx   = withUnsafeBytes(of: UInt64(index).bigEndian) { Array($0) }
     for j in 0..<8 { bytes[4 + j] ^= idx[j] }
@@ -269,13 +280,15 @@ private final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
 
 // MARK: - Share Provider
 
-private final class ShareProvider: UIActivityItemProvider {
-    private let fileURL:     URL
-    private let filename:    String
-    private let contentType: UTType
-    private let contactKey:  SymmetricKey
+// UIActivityItemProvider is @MainActor in UIKit. Stored properties are nonisolated
+// so that item and activityViewController can run on UIKit's background thread.
+private final class ShareProvider: UIActivityItemProvider, @unchecked Sendable {
+    nonisolated let fileURL:     URL
+    nonisolated let filename:    String
+    nonisolated let contentType: UTType
+    nonisolated let contactKey:  SymmetricKey
 
-    init(fileURL: URL, filename: String, contentType: UTType, contactKey: SymmetricKey) {
+    nonisolated init(fileURL: URL, filename: String, contentType: UTType, contactKey: SymmetricKey) {
         self.fileURL     = fileURL
         self.filename    = filename
         self.contentType = contentType
@@ -283,17 +296,25 @@ private final class ShareProvider: UIActivityItemProvider {
         super.init(placeholderItem: Data())
     }
 
+    nonisolated override init(placeholderItem item: Any) {
+        self.fileURL     = URL(fileURLWithPath: "")
+        self.filename    = ""
+        self.contentType = .data
+        self.contactKey  = SymmetricKey(size: .bits256)
+        super.init(placeholderItem: item)
+    }
+
     // Called on a background thread by UIActivityViewController.
-    override var item: Any {
+    nonisolated override var item: Any {
         (try? Decryptor.all(at: self.fileURL, contactKey: self.contactKey)) ?? Data()
     }
 
-    override func activityViewController(
+    nonisolated override func activityViewController(
         _ ac: UIActivityViewController,
         subjectForActivityType type: UIActivity.ActivityType?
     ) -> String { self.filename }
 
-    override func activityViewController(
+    nonisolated override func activityViewController(
         _ ac: UIActivityViewController,
         dataTypeIdentifierForActivityType type: UIActivity.ActivityType?
     ) -> String { self.contentType.identifier }
@@ -318,8 +339,8 @@ private enum AssociatedKeys {
 // MARK: - Encoding helpers
 
 private extension UInt32 {
-    var bigEndianData: Data { withUnsafeBytes(of: self.bigEndian) { Data($0) } }
-    init(bigEndianBytes bytes: some DataProtocol) {
+    nonisolated var bigEndianData: Data { withUnsafeBytes(of: self.bigEndian) { Data($0) } }
+    nonisolated init(bigEndianBytes bytes: some DataProtocol) {
         var v: UInt32 = 0
         _ = withUnsafeMutableBytes(of: &v) { ptr in bytes.copyBytes(to: ptr) }
         self = UInt32(bigEndian: v)
@@ -327,8 +348,8 @@ private extension UInt32 {
 }
 
 private extension UInt64 {
-    var bigEndianData: Data { withUnsafeBytes(of: self.bigEndian) { Data($0) } }
-    init(bigEndianBytes bytes: some DataProtocol) {
+    nonisolated var bigEndianData: Data { withUnsafeBytes(of: self.bigEndian) { Data($0) } }
+    nonisolated init(bigEndianBytes bytes: some DataProtocol) {
         var v: UInt64 = 0
         _ = withUnsafeMutableBytes(of: &v) { ptr in bytes.copyBytes(to: ptr) }
         self = UInt64(bigEndian: v)
@@ -336,5 +357,5 @@ private extension UInt64 {
 }
 
 private extension AES.GCM.Nonce {
-    var dataRepresentation: Data { self.withUnsafeBytes { Data($0) } }
+    nonisolated var dataRepresentation: Data { self.withUnsafeBytes { Data($0) } }
 }

--- a/Occulta/Services/Attachment+Manager.swift
+++ b/Occulta/Services/Attachment+Manager.swift
@@ -337,12 +337,17 @@ final class StreamingEncryptor: @unchecked Sendable {
     func append(_ incoming: Data) throws {
         self.totalBytes += incoming.count
         var offset = 0
+        
         while offset < incoming.count {
             let take = min(self.chunkSize - self.buffer.count, incoming.count - offset)
+            
             self.buffer.append(contentsOf: incoming[offset..<(offset + take)])
+            
             offset += take
+            
             if self.buffer.count == self.chunkSize {
                 try self.flush(self.buffer)
+                
                 self.buffer.removeAll(keepingCapacity: true)
             }
         }
@@ -440,9 +445,12 @@ private final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
                 // that request — avoids a file open/close per 256KB chunk.
                 let handle = try FileHandle(forReadingFrom: self.fileURL)
                 defer { try? handle.close() }
+                _ = fcntl(handle.fileDescriptor, F_NOCACHE, 1)
                 while cursor < end {
                     let length = min(self.header.chunkSize, end - cursor)
-                    let chunk  = try self.decryptChunk(at: cursor, length: length, using: handle)
+                    let chunk  = try autoreleasepool {
+                        try self.decryptChunk(at: cursor, length: length, using: handle)
+                    }
                     dataReq.respond(with: chunk)
                     cursor += chunk.count
                     if chunk.count < length { break }

--- a/Occulta/Services/Attachment+Manager.swift
+++ b/Occulta/Services/Attachment+Manager.swift
@@ -84,6 +84,16 @@ final class AttachmentManager: Sendable {
         }
     }
 
+    // MARK: Read
+
+    func data(at url: URL) async throws -> Data {
+        let key = self.contactKey
+        
+        return try await Task.detached(priority: .userInitiated) {
+            try Decryptor.all(at: url, contactKey: key)
+        }.value
+    }
+
     // MARK: Image
 
     func image(at url: URL) async throws -> UIImage {

--- a/Occulta/Services/Attachment+Manager.swift
+++ b/Occulta/Services/Attachment+Manager.swift
@@ -59,20 +59,18 @@ final class AttachmentManager: Sendable {
                 .appendingPathComponent(UUID().uuidString)
                 .appendingPathExtension(ext)
             
-            defer { try? FileManager.default.removeItem(at: tmp) }
-            
             guard (try? data.writeProtected(to: tmp)) != nil else {
                 continuation.resume(throwing: AttachmentError.invalidImageData)
-                
                 return
             }
-            
+
             let asset = AVURLAsset(url: tmp)
             let gen   = AVAssetImageGenerator(asset: asset)
-            
+
             gen.appliesPreferredTrackTransform = true
             gen.maximumSize                    = CGSize(width: 600, height: 600)
             gen.generateCGImageAsynchronously(for: .zero) { cgImage, _, error in
+                defer { try? FileManager.default.removeItem(at: tmp) }
                 if let cgImage {
                     continuation.resume(returning: UIImage(cgImage: cgImage))
                 } else if let error {

--- a/Occulta/Services/Attachment+Manager.swift
+++ b/Occulta/Services/Attachment+Manager.swift
@@ -257,11 +257,20 @@ private final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
         _ resourceLoader: AVAssetResourceLoader,
         shouldWaitForLoadingOfRequestedResource request: AVAssetResourceLoadingRequest
     ) -> Bool {
-        if let info = request.contentInformationRequest,
-           let h    = try? Decryptor.header(at: self.fileURL, contactKey: self.contactKey) {
-            info.contentType                = UTType.movie.identifier
+        if let info = request.contentInformationRequest {
+            guard let h = try? Decryptor.header(at: self.fileURL, contactKey: self.contactKey) else {
+                request.finishLoading(with: AttachmentError.invalidHeader)
+                return true
+            }
+            let uti = UTType(filenameExtension: self.fileURL.pathExtension)?.identifier
+                   ?? UTType.movie.identifier
+            info.contentType                = uti
             info.contentLength              = Int64(h.plaintextSize)
             info.isByteRangeAccessSupported = true
+            if request.dataRequest == nil {
+                request.finishLoading()
+                return true
+            }
         }
         if let data = request.dataRequest {
             let offset = Int(data.requestedOffset)

--- a/Occulta/Services/Attachment+Manager.swift
+++ b/Occulta/Services/Attachment+Manager.swift
@@ -30,6 +30,56 @@ final class AttachmentManager: Sendable {
         try Encryptor.write(data, contactKey: self.contactKey, to: url)
     }
 
+    nonisolated func encryptWithProgress(_ data: Data, to url: URL) -> AsyncThrowingStream<Double, Error> {
+        let key = self.contactKey
+        
+        return AsyncThrowingStream { continuation in
+            Task.detached(priority: .userInitiated) {
+                do {
+                    try Encryptor.write(data, contactKey: key, to: url) { @Sendable p in
+                        continuation.yield(p)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    // Extracts a thumbnail from raw (plaintext) video data. Writes to a protected
+    // temp file, grabs frame 0, then immediately deletes the temp file.
+    static func videoThumbnail(from data: Data, fileExtension ext: String) async -> UIImage? {
+        try? await withCheckedThrowingContinuation { continuation in
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension(ext)
+            
+            defer { try? FileManager.default.removeItem(at: tmp) }
+            
+            guard (try? data.writeProtected(to: tmp)) != nil else {
+                continuation.resume(throwing: AttachmentError.invalidImageData)
+                
+                return
+            }
+            
+            let asset = AVURLAsset(url: tmp)
+            let gen   = AVAssetImageGenerator(asset: asset)
+            
+            gen.appliesPreferredTrackTransform = true
+            gen.maximumSize                    = CGSize(width: 600, height: 600)
+            gen.generateCGImageAsynchronously(for: .zero) { cgImage, _, error in
+                if let cgImage {
+                    continuation.resume(returning: UIImage(cgImage: cgImage))
+                } else if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(throwing: AttachmentError.invalidImageData)
+                }
+            }
+        }
+    }
+
     // MARK: Image
 
     func image(at url: URL) async throws -> UIImage {
@@ -47,6 +97,7 @@ final class AttachmentManager: Sendable {
             guard let source,
                   let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
             else { throw AttachmentError.invalidImageData }
+            
             return UIImage(cgImage: cgImage)
         }.value
     }
@@ -110,7 +161,12 @@ private struct Header {
 private enum Encryptor {
     nonisolated static let chunkSize = 262_144 // 256 KB
 
-    nonisolated static func write(_ plaintext: Data, contactKey: SymmetricKey, to url: URL) throws {
+    nonisolated static func write(
+        _ plaintext: Data,
+        contactKey: SymmetricKey,
+        to url: URL,
+        onProgress: (@Sendable (Double) -> Void)? = nil
+    ) throws {
         let baseNonce = AES.GCM.Nonce()
         let keySalt   = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
         let fileKey   = derivedFileKey(contactKey: contactKey, salt: keySalt)
@@ -138,6 +194,7 @@ private enum Encryptor {
             )
             output.append(contentsOf: box.ciphertext)
             output.append(contentsOf: box.tag)
+            onProgress?(Double(i + 1) / Double(chunks))
         }
 
         try output.writeProtected(to: url)

--- a/Occulta/Services/Contact+Manager.swift
+++ b/Occulta/Services/Contact+Manager.swift
@@ -1073,7 +1073,7 @@ extension ContactManager {
         guard
             let enc  = contact.maxBundleVersion,
             let raw  = try? crypto.decrypt(data: enc),
-            let byte = raw?.first
+            let byte = raw.first
         else { return .v3fs }
         return WireHandle.byteToVersion(byte) ?? .v3fs
     }

--- a/Occulta/Services/Contact+Manager.swift
+++ b/Occulta/Services/Contact+Manager.swift
@@ -898,15 +898,13 @@ extension ContactManager {
     /// sends back a `.forwardSecret` bundle using one of our prekeys — cryptographic
     /// proof they stored the batch. Only then is the batch cleared.
     func encryptBundle(
-        data: Data? = nil,
+        basket: Basket? = nil,
         for identifier: String,
         shardOperations: [OccultaBundle.ShardOperation]? = nil,
         custodyManifest: [UUID]? = nil,
         expectedShards: [UUID]? = nil
     ) throws -> Data {
-        guard data != nil || shardOperations != nil || custodyManifest != nil || expectedShards != nil else { throw Errors.messageHasNoData }
-        
-        if let data, data.isEmpty { throw Errors.messageHasNoData }
+        guard basket != nil || shardOperations != nil || custodyManifest != nil || expectedShards != nil else { throw Errors.messageHasNoData }
         
         guard let contact = try self.fetchContact(by: identifier) else { throw Errors.contactNotFound }
 
@@ -943,25 +941,41 @@ extension ContactManager {
             outboundBatch = try contact.loadPendingBatch()
         }
 
-        // ── 3. Build and seal payload ─────────────────────────────────────
-        let messageData   = data ?? Data("Occulta vault operation. Please update your app.".utf8)
+        // ── 3. Resolve target wire format for this contact ────────────────
+        let cryptoOps     = Manager.Crypto()
+        let targetVersion = Self.resolveTargetVersion(for: contact, using: cryptoOps)
+
+        // ── 4. Build and seal payload ─────────────────────────────────────
+        let messageData: Data
+        if let basket {
+            messageData = targetVersion == .v4
+                ? try WireHandle.encode(basket: basket)
+                : try JSONEncoder().encode(basket)
+        } else {
+            messageData = Data("Occulta vault operation. Please update your app.".utf8)
+        }
+
         let sealedPayload = OccultaBundle.SealedPayload(
             message:         messageData,
             prekeyBatch:     outboundBatch,
             shardOperations: shardOperations,
             custodyManifest: custodyManifest,
-            expectedShards:  expectedShards
+            expectedShards:  expectedShards,
+            appVersion:      Bundle.main.appVersion
         )
-        let encoded = try JSONEncoder().encode(sealedPayload)
+        let encoded = targetVersion == .v4
+            ? try WireHandle.encode(payload: sealedPayload)
+            : try JSONEncoder().encode(sealedPayload)
 
         // contactPrekey == nil in shard mode → Manager.Crypto.seal uses longTermFallback.
         let bundle = try Manager.Crypto().seal(
             message:           encoded,
             contactPrekey:     contactPrekey,
             recipientMaterial: recipientMaterial,
-            quantumMaterial:   quantumMaterial
+            quantumMaterial:   quantumMaterial,
+            version:           targetVersion
         )
-        let encodedBundle = try bundle.encoded()
+        let encodedBundle = try bundle.encoded(version: targetVersion)
         
         if contactPrekey != nil {
             // Persist prekey state only when it was mutated (message mode).
@@ -1052,8 +1066,20 @@ extension ContactManager {
 }
  
 extension ContactManager {
+
+    /// Resolve the wire format version to use when sending to a contact.
+    /// Reads the encrypted `maxBundleVersion` byte and maps it back to a `Version`.
+    static func resolveTargetVersion(for contact: Contact.Profile, using crypto: Manager.Crypto) -> OccultaBundle.Version {
+        guard
+            let enc  = contact.maxBundleVersion,
+            let raw  = try? crypto.decrypt(data: enc),
+            let byte = raw?.first
+        else { return .v3fs }
+        return WireHandle.byteToVersion(byte) ?? .v3fs
+    }
+
     private func verifyConsistency(for bundle: OccultaBundle) throws {
-        guard bundle.version == .v3fs else { throw Errors.unsupportedBundleVersion }
+        guard bundle.version == .v3fs || bundle.version == .v4 else { throw Errors.unsupportedBundleVersion }
         // Defence-in-depth: never touch a bundle whose version or mode was
         // produced by a future build we don't understand. `Version`/`Mode` both
         // decode unknown raw values to `.unsupported` — see OccultaBundle.swift.
@@ -1247,9 +1273,22 @@ extension ContactManager {
             debugPrint("Storage complete. Ready to send new prekey batch in the next message.")
         }
         
-        let decodedPayload = try JSONDecoder().decode(OccultaBundle.SealedPayload.self, from: decryptedSealedPayload)
- 
-        // ── 4. Store inbound prekey batch ────────────────────────────────
+        let decodedPayload: OccultaBundle.SealedPayload
+        if bundle.version == .v4 {
+            decodedPayload = try WireHandle.decode(payload: decryptedSealedPayload)
+        } else {
+            decodedPayload = try JSONDecoder().decode(OccultaBundle.SealedPayload.self, from: decryptedSealedPayload)
+        }
+
+        // ── 4. Update contact's capability from sender's app version ──────
+        if let appVersion = decodedPayload.appVersion {
+            let maxVersion = OccultaBundle.Version.max(forAppVersion: appVersion)
+            if let byte = maxVersion.wireByte {
+                sender.maxBundleVersion = try cryptoOps.encrypt(data: Data([byte]))
+            }
+        }
+
+        // ── 6. Store inbound prekey batch ────────────────────────────────
         if let inboundBatch = decodedPayload.prekeyBatch {
             debugPrint("Decrypting bundle containing inbound prekey sync batch...")
             
@@ -1276,7 +1315,7 @@ extension ContactManager {
             try sender.syncInboundPrekeys(blobs, date: inboundBatch.generatedAt)
         }
  
-        // ── 5. Persist ───────────────────────────────────────────────────
+        // ── 7. Persist ───────────────────────────────────────────────────
         try self.modelContext.save()
         
         debugPrint("Saved after decrypt. Inbound prekeys now: \(sender.availableInboundPrekeyCount), sender: \(sender.givenName.decrypt()), pending batch: \(sender.hasPendingBatch)")

--- a/Occulta/Services/Contact+Manager.swift
+++ b/Occulta/Services/Contact+Manager.swift
@@ -566,6 +566,21 @@ extension ContactManager {
         return encryptedData
     }
     
+    /// Derives the stable per-contact base key used to encrypt file attachments at rest.
+    /// Callers pass this into `AttachmentManager(contactKey:)`.
+    func fileEncryptionKey(for identifier: String) throws -> SymmetricKey {
+        guard let contact = try self.fetchContact(by: identifier) else {
+            throw ContactManager.Errors.contactNotFound
+        }
+        guard let encrypted = contact.contactPublicKeys?.last?.material,
+              let material   = try? self.cryptoManager.decrypt(data: encrypted)
+        else { throw ContactManager.Errors.contactHasNoKeys }
+        guard let key = Manager.Key().createSharedSecret(using: material) else {
+            throw ContactManager.Errors.contactHasNoKeys
+        }
+        return key
+    }
+
     private func encrypt(data: Data, using material: Data) throws -> Data? {
         try self.cryptoManager.encrypt(message: data, using: material)
     }

--- a/Occulta/Services/Key+Manager.swift
+++ b/Occulta/Services/Key+Manager.swift
@@ -47,7 +47,7 @@ struct SaltInfo {
     /// reconstruction. Domain-separated from kShardCustodyKeyInfo so a custody
     /// blob and a reconstruct blob are never decryptable with the same key.
     static let kRecoveryBufferKeyInfo = "Occulta-v1-recovery-buffer-2026".data(using: .utf8)!
-    static let kFileKeyInfo           = "Occulta-v1-file-key-2025".data(using: .utf8)!
+    nonisolated static let kFileKeyInfo           = "Occulta-v1-file-key-2025".data(using: .utf8)!
 }
 
 // MARK: - SE Key Inventory

--- a/Occulta/Services/Key+Manager.swift
+++ b/Occulta/Services/Key+Manager.swift
@@ -47,6 +47,7 @@ struct SaltInfo {
     /// reconstruction. Domain-separated from kShardCustodyKeyInfo so a custody
     /// blob and a reconstruct blob are never decryptable with the same key.
     static let kRecoveryBufferKeyInfo = "Occulta-v1-recovery-buffer-2026".data(using: .utf8)!
+    static let kFileKeyInfo           = "Occulta-v1-file-key-2025".data(using: .utf8)!
 }
 
 // MARK: - SE Key Inventory

--- a/Occulta/UI/Tabs/Contacts/V2/ActivityView.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ActivityView.swift
@@ -11,9 +11,16 @@ import Foundation
 struct ActivityView: UIViewControllerRepresentable {
     let activityItems: [Any]
     var applicationActivities: [UIActivity]? = nil
+    /// Called when the activity sheet closes — both on completion and cancellation.
+    /// `completed` is true only when the user picked an activity and it finished successfully.
+    var onComplete: ((Bool) -> Void)? = nil
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: self.activityItems, applicationActivities: self.applicationActivities)
+        let vc = UIActivityViewController(activityItems: self.activityItems, applicationActivities: self.applicationActivities)
+        vc.completionWithItemsHandler = { _, completed, _, _ in
+            self.onComplete?(completed)
+        }
+        return vc
     }
 
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) { }

--- a/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
@@ -1,6 +1,8 @@
 import Foundation
 import SwiftUI
 import PhotosUI
+import Photos
+import AVFoundation
 import UniformTypeIdentifiers
 
 // MARK: - PendingImport
@@ -83,7 +85,8 @@ final class ComposeViewModel {
             }
 
             do {
-                try await self.streamVideo(provider: provider, typeID: typeID,
+                try await self.streamVideo(assetID: result.assetIdentifier,
+                                           provider: provider, typeID: typeID,
                                            pendingID: pending.id, ext: ext,
                                            filename: filename, url: url, manager: manager)
             } catch {
@@ -248,6 +251,102 @@ final class ComposeViewModel {
     // MARK: Private
 
     private func streamVideo(
+        assetID:   String?,
+        provider:  NSItemProvider,
+        typeID:    String,
+        pendingID: UUID,
+        ext:       String,
+        filename:  String,
+        url:       URL,
+        manager:   AttachmentManager
+    ) async throws {
+        if let assetID {
+            try await self.streamVideoPOSIX(assetID: assetID, pendingID: pendingID,
+                                            ext: ext, filename: filename, url: url, manager: manager)
+        } else {
+            try await self.streamVideoProvider(provider: provider, typeID: typeID,
+                                               pendingID: pendingID, ext: ext,
+                                               filename: filename, url: url, manager: manager)
+        }
+    }
+
+    // POSIX path: F_NOCACHE + F_RDAHEAD=0 on the source fd keeps the kernel buffer
+    // cache from accumulating pages behind the read cursor, bounding RSS to one chunk.
+    private func streamVideoPOSIX(
+        assetID:   String,
+        pendingID: UUID,
+        ext:       String,
+        filename:  String,
+        url:       URL,
+        manager:   AttachmentManager
+    ) async throws {
+        let status = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
+        guard status == .authorized || status == .limited else {
+            throw ImportError.photosAccessDenied
+        }
+
+        let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [assetID], options: nil)
+        guard let asset = fetchResult.firstObject else { throw ImportError.assetNotFound }
+
+        let opts = PHVideoRequestOptions()
+        opts.isNetworkAccessAllowed = true
+        opts.deliveryMode = .automatic
+
+        let videoURL: URL = try await withCheckedThrowingContinuation { cont in
+            var resumed = false
+            PHImageManager.default().requestAVAsset(forVideo: asset, options: opts) { avAsset, _, info in
+                guard !resumed else { return }
+                resumed = true
+                if let err = info?[PHImageErrorKey] as? Error { cont.resume(throwing: err) }
+                else if let ua = avAsset as? AVURLAsset       { cont.resume(returning: ua.url) }
+                else                                           { cont.resume(throwing: ImportError.noVideoResource) }
+            }
+        }
+
+        await MainActor.run {
+            if let idx = self.pendingImports.firstIndex(where: { $0.id == pendingID }) {
+                self.pendingImports[idx].isLoading = false
+            }
+        }
+
+        let encryptor = try manager.streamingEncryptor(to: url)
+
+        // Blocking I/O — run on a detached task, not the cooperative pool.
+        try await Task.detached(priority: .userInitiated) {
+            let fd = open(videoURL.path(percentEncoded: false), O_RDONLY)
+            guard fd >= 0 else { throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno)) }
+            defer { close(fd) }
+
+            fcntl(fd, F_NOCACHE, 1)  // bypass unified buffer cache
+            fcntl(fd, F_RDAHEAD, 0)  // disable kernel readahead (int 0, not a pointer)
+
+            let chunkSize = 65_536
+            var rawBuf: UnsafeMutableRawPointer? = nil
+            guard posix_memalign(&rawBuf, Int(sysconf(_SC_PAGESIZE)), chunkSize) == 0,
+                  let buf = rawBuf else {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+            }
+            defer { free(buf) }
+
+            while true {
+                let n = read(fd, buf, chunkSize)
+                if n == 0 { break }
+                if n < 0  { throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno)) }
+                // bytesNoCopy with .none deallocator: buf is reused each iteration;
+                // append() copies into its internal buffer before returning.
+                try encryptor.append(Data(bytesNoCopy: buf, count: n, deallocator: .none))
+            }
+            try encryptor.finalize()
+        }.value
+
+        await MainActor.run {
+            self.pendingImports.removeAll { $0.id == pendingID }
+            self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
+        }
+    }
+
+    // NSItemProvider fallback — no Photos authorization needed, picker grant is sufficient.
+    private func streamVideoProvider(
         provider:  NSItemProvider,
         typeID:    String,
         pendingID: UUID,
@@ -314,13 +413,15 @@ struct FileExtensions {
 }
 
 enum ImportError: LocalizedError {
+    case photosAccessDenied
     case assetNotFound
     case noVideoResource
 
     var errorDescription: String? {
         switch self {
-        case .assetNotFound:   return "Could not find the selected video."
-        case .noVideoResource: return "The selected item has no video resource."
+        case .photosAccessDenied: return "Photos access is required to import videos."
+        case .assetNotFound:      return "Could not find the selected video."
+        case .noVideoResource:    return "The selected item has no video resource."
         }
     }
 }

--- a/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
@@ -1,0 +1,335 @@
+import Foundation
+import SwiftUI
+import PhotosUI
+import UniformTypeIdentifiers
+
+// MARK: - PendingImport
+
+struct PendingImport: Identifiable {
+    let id       = UUID()
+    let filename: String
+    let ext:      String
+    var thumbnail: UIImage? = nil
+    var progress:  Double   = 0
+    var isLoading: Bool     = true
+}
+
+// MARK: - ComposeViewModel
+
+@Observable
+final class ComposeViewModel {
+    let identifier: String
+
+    var messages:       [Occulta.File]  = []
+    var draftText:      String          = ""
+    var pendingImports: [PendingImport] = []
+    var encryptedURL:   URL?            = nil
+    var isShowingError  = false
+    var errorMessage    = ""
+
+    private(set) var attachmentManager: AttachmentManager? = nil
+
+    init(identifier: String) {
+        self.identifier = identifier
+    }
+
+    // MARK: Setup
+
+    func setup(contactManager: ContactManager) {
+        guard let key = try? contactManager.fileEncryptionKey(for: self.identifier) else { return }
+        self.attachmentManager = AttachmentManager(contactKey: key)
+    }
+
+    // MARK: Text
+
+    func addText() {
+        let trimmed = self.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        self.messages.append(Occulta.File(content: trimmed.data(using: .utf8), format: .text, date: Date()))
+        self.draftText = ""
+    }
+
+    // MARK: Media import
+
+    func handleMedia(_ result: PHPickerResult) async {
+        let provider = result.itemProvider
+        let typeID   = provider.registeredTypeIdentifiers.first ?? UTType.data.identifier
+        let ext      = UTType(typeID)?.preferredFilenameExtension ?? "bin"
+        let filename = "media_\(UUID().uuidString.prefix(8))"
+        let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
+        let isVideo  = FileExtensions.Video(rawValue: ext) != nil
+        let manager  = self.attachmentManager
+
+        if isVideo {
+            guard let manager else {
+                await MainActor.run { self.showError("Secure storage not ready.") }
+                return
+            }
+            let pending = PendingImport(filename: filename, ext: ext)
+            await MainActor.run { self.pendingImports.append(pending) }
+
+            let thumbTypeID = "com.apple.private.photos.thumbnail.standard"
+            if provider.hasItemConformingToTypeIdentifier(thumbTypeID) {
+                Task {
+                    if let data = try? await loadItemData(from: provider, typeID: thumbTypeID),
+                       let img  = UIImage(data: data) {
+                        await MainActor.run {
+                            if let idx = self.pendingImports.firstIndex(where: { $0.id == pending.id }) {
+                                self.pendingImports[idx].thumbnail = img
+                            }
+                        }
+                    }
+                }
+            }
+
+            do {
+                try await self.streamVideo(provider: provider, typeID: typeID,
+                                           pendingID: pending.id, ext: ext,
+                                           filename: filename, url: url, manager: manager)
+            } catch {
+                await MainActor.run {
+                    self.pendingImports.removeAll { $0.id == pending.id }
+                    self.showError(error.localizedDescription)
+                }
+            }
+        } else {
+            do {
+                let data = try await loadItemData(from: provider, typeID: typeID)
+                try await Task.detached(priority: .userInitiated) {
+                    if let manager {
+                        try manager.encrypt(data, to: url)
+                    } else {
+                        try data.writeProtected(to: url)
+                    }
+                }.value
+                await MainActor.run {
+                    self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
+                }
+            } catch {
+                await MainActor.run { self.showError(error.localizedDescription) }
+            }
+        }
+    }
+
+    func handleFile(_ result: Result<[URL], Error>) {
+        Task {
+            do {
+                guard let srcURL = try result.get().first,
+                      srcURL.startAccessingSecurityScopedResource() else { return }
+                defer { srcURL.stopAccessingSecurityScopedResource() }
+
+                let filename = srcURL.deletingPathExtension().lastPathComponent
+                let ext      = srcURL.pathExtension
+                let tmp      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
+                let manager  = self.attachmentManager
+
+                try await Task.detached(priority: .userInitiated) {
+                    if let manager {
+                        let source    = try FileHandle(forReadingFrom: srcURL)
+                        let encryptor = try manager.streamingEncryptor(to: tmp)
+                        
+                        defer { try? source.close() }
+                        
+                        while let chunk = try source.read(upToCount: 65_536), !chunk.isEmpty {
+                            try encryptor.append(chunk)
+                        }
+                        try encryptor.finalize()
+                    } else {
+                        let data = try Data(contentsOf: srcURL, options: .mappedIfSafe)
+                        try data.writeProtected(to: tmp)
+                    }
+                }.value
+
+                await MainActor.run {
+                    self.messages.append(Occulta.File(url: tmp, format: .file(.init(name: filename, extension: ext)), date: Date()))
+                }
+            } catch {
+                await MainActor.run { self.showError(error.localizedDescription) }
+            }
+        }
+    }
+
+    // MARK: Bundle encryption
+
+    func encrypt(
+        contactManager:      ContactManager,
+        shardCustodyManager: ShardCustodyManager?,
+        vaultManager:        VaultManager?
+    ) async {
+        do {
+            var allFiles = self.messages
+            let text = self.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                allFiles.append(Occulta.File(content: text.data(using: .utf8), format: .text, date: Date()))
+            }
+
+            let manager = self.attachmentManager
+            let processed: [Occulta.File] = try await withThrowingTaskGroup(of: Occulta.File.self) { group in
+                for file in allFiles {
+                    if let fileURL = file.url {
+                        group.addTask {
+                            let data: Data
+                            if let manager {
+                                data = try await manager.data(at: fileURL)
+                            } else {
+                                (data, _) = try await URLSession.shared.data(from: fileURL)
+                            }
+                            return Occulta.File(content: data, format: file.format, date: file.date)
+                        }
+                    } else {
+                        let captured = file
+                        group.addTask { captured }
+                    }
+                }
+                var results: [Occulta.File] = []
+                for try await file in group { results.append(file) }
+                return results.sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
+            }
+
+            let basket     = Basket(files: processed)
+            let contactPub = try? contactManager.currentPublicKey(forIdentifier: self.identifier)
+            let shardOps   = try shardCustodyManager?.buildShardOperations(for: self.identifier, currentContactPublicKey: contactPub) ?? []
+            let manifest   = try? shardCustodyManager?.buildCustodyManifest(for: self.identifier)
+            let expected: [UUID]?
+            if let custody = shardCustodyManager, let vm = vaultManager {
+                expected = try? custody.buildExpectedShards(for: self.identifier, vaultManager: vm)
+            } else {
+                expected = nil
+            }
+
+            let encrypted: Data
+            do {
+                encrypted = try contactManager.encryptBundle(
+                    basket:          basket,
+                    for:             self.identifier,
+                    shardOperations: shardOps.isEmpty ? nil : shardOps,
+                    custodyManifest: manifest,
+                    expectedShards:  expected
+                )
+            } catch ContactManager.Errors.trusteeLacksQuantumMaterial {
+                encrypted = try contactManager.encryptBundle(basket: basket, for: self.identifier)
+            }
+
+            guard !encrypted.isEmpty else {
+                await MainActor.run { self.showError("Encryption failed. Try again.") }
+                return
+            }
+
+            let name = UUID().uuidString.components(separatedBy: "-").last ?? "msg"
+            let outURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).occ")
+            try encrypted.writeProtected(to: outURL)
+            await MainActor.run { self.encryptedURL = outURL }
+        } catch {
+            await MainActor.run { self.showError(error.localizedDescription) }
+        }
+    }
+
+    // MARK: Lifecycle
+
+    func deleteMessage(_ file: Occulta.File) {
+        if let url = file.url { try? FileManager.default.removeItem(at: url) }
+        self.messages.removeAll { $0.id == file.id }
+    }
+
+    func clearAfterEncrypt() {
+        for file in self.messages {
+            if let url = file.url { try? FileManager.default.removeItem(at: url) }
+        }
+        self.messages = []
+        self.draftText = ""
+    }
+
+    func cleanup() {
+        for file in self.messages {
+            if let url = file.url { try? FileManager.default.removeItem(at: url) }
+        }
+    }
+
+    // MARK: Private
+
+    private func streamVideo(
+        provider:  NSItemProvider,
+        typeID:    String,
+        pendingID: UUID,
+        ext:       String,
+        filename:  String,
+        url:       URL,
+        manager:   AttachmentManager
+    ) async throws {
+        await MainActor.run {
+            if let idx = self.pendingImports.firstIndex(where: { $0.id == pendingID }) {
+                self.pendingImports[idx].isLoading = false
+            }
+        }
+
+        let encryptor = try manager.streamingEncryptor(to: url)
+        let pageSize  = Int(getpagesize())
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, providerError in
+                do {
+                    if let err = providerError { throw err }
+                    guard let data else { throw ImportError.noVideoResource }
+                    var encryptError: Error? = nil
+                    data.withUnsafeBytes { rawPtr in
+                        guard let base = rawPtr.baseAddress else { return }
+                        var offset = 0
+                        while offset < data.count, encryptError == nil {
+                            let take = min(65_536, data.count - offset)
+                            autoreleasepool {
+                                do { try encryptor.append(Data(bytes: base.advanced(by: offset), count: take)) }
+                                catch { encryptError = error }
+                            }
+                            let adviseLen = ((take + pageSize - 1) / pageSize) * pageSize
+                            madvise(UnsafeMutableRawPointer(mutating: base.advanced(by: offset)), adviseLen, MADV_DONTNEED)
+                            offset += take
+                        }
+                    }
+                    if let err = encryptError { throw err }
+                    try encryptor.finalize()
+                    cont.resume()
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+
+        await MainActor.run {
+            self.pendingImports.removeAll { $0.id == pendingID }
+            self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
+        }
+    }
+
+    private func showError(_ message: String) {
+        self.errorMessage = message
+        self.isShowingError = true
+    }
+}
+
+// MARK: - Supporting types
+
+struct FileExtensions {
+    enum Video: String { case mov, mp4, m4v }
+    enum Image: String { case jpg, jpeg, png, heic }
+}
+
+enum ImportError: LocalizedError {
+    case assetNotFound
+    case noVideoResource
+
+    var errorDescription: String? {
+        switch self {
+        case .assetNotFound:   return "Could not find the selected video."
+        case .noVideoResource: return "The selected item has no video resource."
+        }
+    }
+}
+
+private func loadItemData(from provider: NSItemProvider, typeID: String) async throws -> Data {
+    try await withCheckedThrowingContinuation { cont in
+        provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, error in
+            if let data { cont.resume(returning: data) }
+            else { cont.resume(throwing: error ?? ImportError.assetNotFound) }
+        }
+    }
+}

--- a/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
@@ -134,14 +134,15 @@ final class ComposeViewModel {
                 try await Task.detached(priority: .userInitiated) {
                     if let manager {
                         let source    = try FileHandle(forReadingFrom: srcURL)
-                        let encryptor = try manager.streamingEncryptor(to: tmp)
+                        let encryptor = try await manager.streamingEncryptor(to: tmp)
                         
                         defer { try? source.close() }
                         
                         while let chunk = try source.read(upToCount: 65_536), !chunk.isEmpty {
-                            try encryptor.append(chunk)
+                            try await encryptor.append(chunk)
                         }
-                        try encryptor.finalize()
+                        
+                        try await encryptor.finalize()
                     } else {
                         let data = try Data(contentsOf: srcURL, options: .mappedIfSafe)
                         try data.writeProtected(to: tmp)
@@ -321,6 +322,7 @@ final class ComposeViewModel {
 
             let chunkSize = 65_536
             var rawBuf: UnsafeMutableRawPointer? = nil
+            
             guard posix_memalign(&rawBuf, Int(sysconf(_SC_PAGESIZE)), chunkSize) == 0,
                   let buf = rawBuf else {
                 throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
@@ -333,9 +335,9 @@ final class ComposeViewModel {
                 if n < 0  { throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno)) }
                 // bytesNoCopy with .none deallocator: buf is reused each iteration;
                 // append() copies into its internal buffer before returning.
-                try encryptor.append(Data(bytesNoCopy: buf, count: n, deallocator: .none))
+                try await encryptor.append(Data(bytesNoCopy: buf, count: n, deallocator: .none))
             }
-            try encryptor.finalize()
+            try await encryptor.finalize()
         }.value
     }
 

--- a/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
@@ -133,10 +133,11 @@ final class ComposeViewModel {
 
                 try await Task.detached(priority: .userInitiated) {
                     if let manager {
-                        let source    = try FileHandle(forReadingFrom: srcURL)
-                        let encryptor = try await manager.streamingEncryptor(to: tmp)
+                        let source = try FileHandle(forReadingFrom: srcURL)
                         
                         defer { try? source.close() }
+                        let encryptor = try await manager.streamingEncryptor(to: tmp)
+                        
                         
                         while let chunk = try source.read(upToCount: 65_536), !chunk.isEmpty {
                             try await encryptor.append(chunk)

--- a/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
@@ -11,9 +11,8 @@ struct PendingImport: Identifiable {
     let id       = UUID()
     let filename: String
     let ext:      String
-    var thumbnail: UIImage? = nil
-    var progress:  Double   = 0
-    var isLoading: Bool     = true
+    var progress:  Double = 0
+    var isLoading: Bool   = true
 }
 
 // MARK: - ComposeViewModel
@@ -25,6 +24,7 @@ final class ComposeViewModel {
     var messages:       [Occulta.File]  = []
     var draftText:      String          = ""
     var pendingImports: [PendingImport] = []
+    var thumbnails:     [URL: UIImage]  = [:]
     var encryptedURL:   URL?            = nil
     var isShowingError  = false
     var errorMessage    = ""
@@ -71,28 +71,33 @@ final class ComposeViewModel {
             await MainActor.run { self.pendingImports.append(pending) }
 
             let thumbTypeID = "com.apple.private.photos.thumbnail.standard"
-            if provider.hasItemConformingToTypeIdentifier(thumbTypeID) {
-                Task {
-                    if let data = try? await loadItemData(from: provider, typeID: thumbTypeID),
-                       let img  = UIImage(data: data) {
-                        await MainActor.run {
-                            if let idx = self.pendingImports.firstIndex(where: { $0.id == pending.id }) {
-                                self.pendingImports[idx].thumbnail = img
-                            }
-                        }
-                    }
-                }
+            let thumbTask = Task<UIImage?, Never> {
+                guard provider.hasItemConformingToTypeIdentifier(thumbTypeID),
+                      let data = try? await loadItemData(from: provider, typeID: thumbTypeID) else { return nil }
+                return UIImage(data: data)
             }
 
             do {
                 try await self.streamVideo(assetID: result.assetIdentifier,
                                            provider: provider, typeID: typeID,
-                                           pendingID: pending.id, ext: ext,
-                                           filename: filename, url: url, manager: manager)
+                                           pendingID: pending.id, url: url, manager: manager)
             } catch {
+                thumbTask.cancel()
                 await MainActor.run {
                     self.pendingImports.removeAll { $0.id == pending.id }
                     self.showError(error.localizedDescription)
+                }
+                return
+            }
+
+            let thumb = await thumbTask.value
+            await MainActor.run {
+                withTransaction(Transaction(animation: nil)) {
+                    self.pendingImports.removeAll { $0.id == pending.id }
+                    if let img = thumb { self.thumbnails[url] = img }
+                    var file = Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date())
+                    file.id = pending.id
+                    self.messages.append(file)
                 }
             }
         } else {
@@ -255,18 +260,14 @@ final class ComposeViewModel {
         provider:  NSItemProvider,
         typeID:    String,
         pendingID: UUID,
-        ext:       String,
-        filename:  String,
         url:       URL,
         manager:   AttachmentManager
     ) async throws {
         if let assetID {
-            try await self.streamVideoPOSIX(assetID: assetID, pendingID: pendingID,
-                                            ext: ext, filename: filename, url: url, manager: manager)
+            try await self.streamVideoPOSIX(assetID: assetID, pendingID: pendingID, url: url, manager: manager)
         } else {
             try await self.streamVideoProvider(provider: provider, typeID: typeID,
-                                               pendingID: pendingID, ext: ext,
-                                               filename: filename, url: url, manager: manager)
+                                               pendingID: pendingID, url: url, manager: manager)
         }
     }
 
@@ -275,8 +276,6 @@ final class ComposeViewModel {
     private func streamVideoPOSIX(
         assetID:   String,
         pendingID: UUID,
-        ext:       String,
-        filename:  String,
         url:       URL,
         manager:   AttachmentManager
     ) async throws {
@@ -317,8 +316,8 @@ final class ComposeViewModel {
             guard fd >= 0 else { throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno)) }
             defer { close(fd) }
 
-            fcntl(fd, F_NOCACHE, 1)  // bypass unified buffer cache
-            fcntl(fd, F_RDAHEAD, 0)  // disable kernel readahead (int 0, not a pointer)
+            _ = fcntl(fd, F_NOCACHE, 1)  // bypass unified buffer cache
+            _ = fcntl(fd, F_RDAHEAD, 0)  // disable kernel readahead (int 0, not a pointer)
 
             let chunkSize = 65_536
             var rawBuf: UnsafeMutableRawPointer? = nil
@@ -338,11 +337,6 @@ final class ComposeViewModel {
             }
             try encryptor.finalize()
         }.value
-
-        await MainActor.run {
-            self.pendingImports.removeAll { $0.id == pendingID }
-            self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
-        }
     }
 
     // NSItemProvider fallback — no Photos authorization needed, picker grant is sufficient.
@@ -350,8 +344,6 @@ final class ComposeViewModel {
         provider:  NSItemProvider,
         typeID:    String,
         pendingID: UUID,
-        ext:       String,
-        filename:  String,
         url:       URL,
         manager:   AttachmentManager
     ) async throws {
@@ -391,11 +383,6 @@ final class ComposeViewModel {
                     cont.resume(throwing: error)
                 }
             }
-        }
-
-        await MainActor.run {
-            self.pendingImports.removeAll { $0.id == pendingID }
-            self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
         }
     }
 

--- a/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ComposeViewModel.swift
@@ -357,30 +357,24 @@ final class ComposeViewModel {
         }
 
         let encryptor = try manager.streamingEncryptor(to: url)
-        let pageSize  = Int(getpagesize())
 
+        // Read directly from the system-provided URL inside the callback — no plaintext copy written.
+        // The callback runs on a background thread so blocking I/O is fine.
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, providerError in
+            provider.loadFileRepresentation(forTypeIdentifier: typeID) { fileURL, error in
                 do {
-                    if let err = providerError { throw err }
-                    guard let data else { throw ImportError.noVideoResource }
-                    var encryptError: Error? = nil
-                    data.withUnsafeBytes { rawPtr in
-                        guard let base = rawPtr.baseAddress else { return }
-                        var offset = 0
-                        while offset < data.count, encryptError == nil {
-                            let take = min(65_536, data.count - offset)
-                            autoreleasepool {
-                                do { try encryptor.append(Data(bytes: base.advanced(by: offset), count: take)) }
-                                catch { encryptError = error }
-                            }
-                            let adviseLen = ((take + pageSize - 1) / pageSize) * pageSize
-                            madvise(UnsafeMutableRawPointer(mutating: base.advanced(by: offset)), adviseLen, MADV_DONTNEED)
-                            offset += take
-                        }
+                    if let err = error { throw err }
+                    guard let fileURL else { throw ImportError.noVideoResource }
+                    
+                    let source = try FileHandle(forReadingFrom: fileURL)
+                    
+                    defer { try? source.close() }
+                    
+                    while let chunk = try source.read(upToCount: 65_536), !chunk.isEmpty {
+                        try encryptor.append(chunk)
                     }
-                    if let err = encryptError { throw err }
                     try encryptor.finalize()
+                    
                     cont.resume()
                 } catch {
                     cont.resume(throwing: error)

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -7,6 +7,7 @@ import SwiftUI
 import SwiftData
 import PhotosUI
 import UniformTypeIdentifiers
+import CryptoKit
 
 extension Contact {
     struct DetailsV2: View {
@@ -253,6 +254,7 @@ private struct ComposeHeroV2: View {
     @State private var encryptedURL: URL?
     @State private var isShowingError = false
     @State private var errorMessage = ""
+    @State private var sessionKey = SymmetricKey(size: .bits256)
 
     private var isV4: Bool { self.contacts.first?.maxBundleVersion != nil }
 
@@ -377,6 +379,9 @@ private struct ComposeHeroV2: View {
             ActivityView(activityItems: [url], onComplete: { completed in
                 try? FileManager.default.removeItem(at: url)
                 if completed {
+                    for attachment in self.attachments {
+                        if let stagingURL = attachment.url { try? FileManager.default.removeItem(at: stagingURL) }
+                    }
                     self.messageText = ""
                     self.attachments = []
                     self.selectedMediaItems = []
@@ -396,10 +401,11 @@ private struct ComposeHeroV2: View {
     private func handleMedia(_ item: PhotosPickerItem) async {
         do {
             guard let data = try await item.loadTransferable(type: Data.self) else { return }
-            let ext      = item.supportedContentTypes.first?.preferredFilenameExtension ?? "bin"
-            let name     = "media_\(UUID().uuidString.prefix(8))"
-            let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
-            try data.write(to: url)
+            let ext       = item.supportedContentTypes.first?.preferredFilenameExtension ?? "bin"
+            let name      = "media_\(UUID().uuidString.prefix(8))"
+            let encrypted = try AES.GCM.seal(data, using: self.sessionKey).combined!
+            let url       = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try encrypted.write(to: url)
             let file = Occulta.File(url: url, format: .file(.init(name: name, extension: ext)), date: Date())
             await MainActor.run { self.attachments.append(file) }
         } catch {
@@ -413,11 +419,12 @@ private struct ComposeHeroV2: View {
                 guard let url = try result.get().first,
                       url.startAccessingSecurityScopedResource() else { return }
                 defer { url.stopAccessingSecurityScopedResource() }
-                let data  = try await URLSession.shared.data(from: url).0
-                let name  = url.deletingPathExtension().lastPathComponent
-                let ext   = url.pathExtension
-                let tmp   = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
-                try data.write(to: tmp)
+                let data      = try await URLSession.shared.data(from: url).0
+                let name      = url.deletingPathExtension().lastPathComponent
+                let ext       = url.pathExtension
+                let encrypted = try AES.GCM.seal(data, using: self.sessionKey).combined!
+                let tmp       = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+                try encrypted.write(to: tmp)
                 let file = Occulta.File(url: tmp, format: .file(.init(name: name, extension: ext)), date: Date())
                 await MainActor.run { self.attachments.append(file) }
             } catch {
@@ -437,19 +444,16 @@ private struct ComposeHeroV2: View {
                     files.append(Occulta.File(content: text.data(using: .utf8), format: .text, date: Date()))
                 }
 
-                // Resolve URL-based attachments to inline data
+                // Decrypt staging files and load into basket
                 for attachment in self.attachments {
                     if let url = attachment.url {
-                        let (data, _) = try await URLSession.shared.data(from: url)
+                        let encrypted = try Data(contentsOf: url)
+                        let sealedBox = try AES.GCM.SealedBox(combined: encrypted)
+                        let data      = try AES.GCM.open(sealedBox, using: self.sessionKey)
                         files.append(Occulta.File(content: data, format: attachment.format, date: attachment.date))
                     } else {
                         files.append(attachment)
                     }
-                }
-
-                // Staging files have been read into `files` — delete them now
-                for attachment in self.attachments {
-                    if let url = attachment.url { try? FileManager.default.removeItem(at: url) }
                 }
 
                 let basket  = Basket(files: files)

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -414,7 +414,7 @@ private struct ComposeHeroV2: View {
             let ext  = item.supportedContentTypes.first?.preferredFilenameExtension ?? "bin"
             let name = "media_\(UUID().uuidString.prefix(8))"
             let url  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
-            try data.write(to: url, options: .completeFileProtection)
+            try data.writeProtected(to: url)
             let file = Occulta.File(url: url, format: .file(.init(name: name, extension: ext)), date: Date())
             await MainActor.run { self.attachments.append(file) }
         } catch {
@@ -432,7 +432,7 @@ private struct ComposeHeroV2: View {
                 let name = url.deletingPathExtension().lastPathComponent
                 let ext  = url.pathExtension
                 let tmp  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
-                try data.write(to: tmp, options: .completeFileProtection)
+                try data.writeProtected(to: tmp)
                 let file = Occulta.File(url: tmp, format: .file(.init(name: name, extension: ext)), date: Date())
                 await MainActor.run { self.attachments.append(file) }
             } catch {
@@ -502,7 +502,7 @@ private struct ComposeHeroV2: View {
 
                 let name = UUID().uuidString.components(separatedBy: "-").last ?? "msg"
                 let url  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).occ")
-                try encrypted.write(to: url, options: .completeFileProtection)
+                try encrypted.writeProtected(to: url)
 
                 await MainActor.run {
                     self.encryptedURL = url

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -387,6 +387,11 @@ private struct ComposeHeroV2: View {
                     }
                 }
 
+                // Staging files have been read into `files` — delete them now
+                for attachment in self.attachments {
+                    if let url = attachment.url { try? FileManager.default.removeItem(at: url) }
+                }
+
                 let basket  = Basket(files: files)
 
                 let contactPub = try? self.contactManager.currentPublicKey(forIdentifier: self.identifier)

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -7,7 +7,6 @@ import SwiftUI
 import SwiftData
 import PhotosUI
 import UniformTypeIdentifiers
-import CryptoKit
 
 extension Contact {
     struct DetailsV2: View {
@@ -25,8 +24,6 @@ extension Contact {
         // Thread compose state — persists while this contact detail is on the stack
         @State private var threadMessages: [Occulta.File] = []
         @State private var threadMessageText = ""
-        @State private var threadThumbnails: [UUID: Data] = [:]
-        @State private var threadSessionKey = SymmetricKey(size: .bits256)
         @State private var threadSelectedMedia: [PhotosPickerItem] = []
 
         init(identifier: String) {
@@ -69,10 +66,8 @@ extension Contact {
                         if self.useThreadCompose {
                             NavigationLink(destination: ComposableMessage(
                                 identifier: self.identifier,
-                                sessionKey: self.threadSessionKey,
                                 messages: self.$threadMessages,
                                 messageText: self.$threadMessageText,
-                                thumbnails: self.$threadThumbnails,
                                 selectedMediaItems: self.$threadSelectedMedia
                             )) {
                                 HStack {
@@ -268,7 +263,6 @@ private struct ComposeHeroV2: View {
     @State private var encryptedURL: URL?
     @State private var isShowingError = false
     @State private var errorMessage = ""
-    @State private var sessionKey = SymmetricKey(size: .bits256)
 
     private var isV4: Bool { self.contacts.first?.maxBundleVersion != nil }
 
@@ -415,11 +409,10 @@ private struct ComposeHeroV2: View {
     private func handleMedia(_ item: PhotosPickerItem) async {
         do {
             guard let data = try await item.loadTransferable(type: Data.self) else { return }
-            let ext       = item.supportedContentTypes.first?.preferredFilenameExtension ?? "bin"
-            let name      = "media_\(UUID().uuidString.prefix(8))"
-            let encrypted = try AES.GCM.seal(data, using: self.sessionKey).combined!
-            let url       = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-            try encrypted.write(to: url)
+            let ext  = item.supportedContentTypes.first?.preferredFilenameExtension ?? "bin"
+            let name = "media_\(UUID().uuidString.prefix(8))"
+            let url  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
+            try data.write(to: url)
             let file = Occulta.File(url: url, format: .file(.init(name: name, extension: ext)), date: Date())
             await MainActor.run { self.attachments.append(file) }
         } catch {
@@ -433,12 +426,11 @@ private struct ComposeHeroV2: View {
                 guard let url = try result.get().first,
                       url.startAccessingSecurityScopedResource() else { return }
                 defer { url.stopAccessingSecurityScopedResource() }
-                let data      = try await URLSession.shared.data(from: url).0
-                let name      = url.deletingPathExtension().lastPathComponent
-                let ext       = url.pathExtension
-                let encrypted = try AES.GCM.seal(data, using: self.sessionKey).combined!
-                let tmp       = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-                try encrypted.write(to: tmp)
+                let data = try await URLSession.shared.data(from: url).0
+                let name = url.deletingPathExtension().lastPathComponent
+                let ext  = url.pathExtension
+                let tmp  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
+                try data.write(to: tmp)
                 let file = Occulta.File(url: tmp, format: .file(.init(name: name, extension: ext)), date: Date())
                 await MainActor.run { self.attachments.append(file) }
             } catch {
@@ -458,12 +450,10 @@ private struct ComposeHeroV2: View {
                     files.append(Occulta.File(content: text.data(using: .utf8), format: .text, date: Date()))
                 }
 
-                // Decrypt staging files and load into basket
+                // Resolve URL-based attachments to inline data
                 for attachment in self.attachments {
                     if let url = attachment.url {
-                        let encrypted = try Data(contentsOf: url)
-                        let sealedBox = try AES.GCM.SealedBox(combined: encrypted)
-                        let data      = try AES.GCM.open(sealedBox, using: self.sessionKey)
+                        let (data, _) = try await URLSession.shared.data(from: url)
                         files.append(Occulta.File(content: data, format: attachment.format, date: attachment.date))
                     } else {
                         files.append(attachment)

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -313,7 +313,16 @@ private struct ComposeHeroV2: View {
                       allowsMultipleSelection: false) { result in
             self.handleFile(result)
         }
-        .sheet(item: self.$encryptedURL) { url in ActivityView(activityItems: [url]) }
+        .sheet(item: self.$encryptedURL) { url in
+            ActivityView(activityItems: [url], onComplete: { completed in
+                try? FileManager.default.removeItem(at: url)
+                if completed {
+                    self.messageText = ""
+                    self.attachments = []
+                    self.selectedMediaItems = []
+                }
+            })
+        }
         .alert("Error", isPresented: self.$isShowingError) {
             Button("OK") { }
         } message: {
@@ -421,9 +430,6 @@ private struct ComposeHeroV2: View {
                 try encrypted.write(to: url)
 
                 await MainActor.run {
-                    self.messageText = ""
-                    self.attachments = []
-                    self.selectedMediaItems = []
                     self.encryptedURL = url
                 }
             } catch {

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -412,7 +412,7 @@ private struct ComposeHeroV2: View {
             let ext  = item.supportedContentTypes.first?.preferredFilenameExtension ?? "bin"
             let name = "media_\(UUID().uuidString.prefix(8))"
             let url  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
-            try data.write(to: url)
+            try data.write(to: url, options: .completeFileProtection)
             let file = Occulta.File(url: url, format: .file(.init(name: name, extension: ext)), date: Date())
             await MainActor.run { self.attachments.append(file) }
         } catch {
@@ -430,7 +430,7 @@ private struct ComposeHeroV2: View {
                 let name = url.deletingPathExtension().lastPathComponent
                 let ext  = url.pathExtension
                 let tmp  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
-                try data.write(to: tmp)
+                try data.write(to: tmp, options: .completeFileProtection)
                 let file = Occulta.File(url: tmp, format: .file(.init(name: name, extension: ext)), date: Date())
                 await MainActor.run { self.attachments.append(file) }
             } catch {
@@ -500,7 +500,7 @@ private struct ComposeHeroV2: View {
 
                 let name = UUID().uuidString.components(separatedBy: "-").last ?? "msg"
                 let url  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).occ")
-                try encrypted.write(to: url)
+                try encrypted.write(to: url, options: .completeFileProtection)
 
                 await MainActor.run {
                     self.encryptedURL = url

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -353,13 +353,12 @@ private struct ComposeHeroV2: View {
                 }
 
                 let basket  = Basket(files: files)
-                let encoded = try JSONEncoder().encode(basket)
-                
+
                 let contactPub = try? self.contactManager.currentPublicKey(forIdentifier: self.identifier)
                 let shardOps   = try self.shardCustodyManager?.buildShardOperations(for: self.identifier, currentContactPublicKey: contactPub) ?? []
                 let manifest_  = try? self.shardCustodyManager?.buildCustodyManifest(for: self.identifier)
                 let expected   = try? self.shardCustodyManager.flatMap { try $0.buildExpectedShards(for: self.identifier, vaultManager: self.vaultManager!) }
-                
+
                 #if DEBUG
                 debugPrint("Manifest: \(manifest_?.description ?? "nil")")
                 debugPrint("Expected: \(expected?.description ?? "nil")")
@@ -369,7 +368,7 @@ private struct ComposeHeroV2: View {
                 let encrypted: Data
                 do {
                     encrypted = try self.contactManager.encryptBundle(
-                        data:            encoded,
+                        basket:          basket,
                         for:             identifier,
                         shardOperations: shardOps.isEmpty ? nil : shardOps,
                         custodyManifest: manifest_,
@@ -379,8 +378,8 @@ private struct ComposeHeroV2: View {
                     // Quantum material corrupted or missing — fall back to classical,
                     // strip shard ops (they stay pending and will retry after re-exchange).
                     encrypted = try self.contactManager.encryptBundle(
-                        data: encoded,
-                        for:  identifier
+                        basket: basket,
+                        for:    identifier
                     )
                 } catch {
                     encrypted = Data()

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -20,14 +20,12 @@ extension Contact {
         @State private var keyDetailsExpanded = false
         @State private var displayingVerificationInfo = false
         @State private var useThreadCompose = false
-
-        // Thread compose state — persists while this contact detail is on the stack
-        @State private var threadMessages: [Occulta.File] = []
-        @State private var threadMessageText = ""
+        @State private var composeVM: ComposeViewModel
 
         init(identifier: String) {
             self.identifier = identifier
             self._contacts = Query(filter: #Predicate { $0.identifier == identifier })
+            self._composeVM = State(initialValue: ComposeViewModel(identifier: identifier))
         }
 
         private var profile: Contact.Profile? { self.contacts.first }
@@ -63,15 +61,19 @@ extension Contact {
                         ComposeStyleToggle(useThread: self.$useThreadCompose)
 
                         if self.useThreadCompose {
-                            NavigationLink(destination: ComposableMessage(
-                                identifier: self.identifier,
-                                messages: self.$threadMessages,
-                                messageText: self.$threadMessageText
-                            )) {
+                            NavigationLink(destination: ComposableMessage(vm: self.composeVM)) {
                                 HStack {
                                     Text("Open thread")
                                         .font(.system(size: 14, weight: .semibold))
                                         .foregroundStyle(.white)
+                                    if !self.composeVM.messages.isEmpty {
+                                        Text("\(self.composeVM.messages.count)")
+                                            .font(.system(size: 10, weight: .bold, design: .monospaced))
+                                            .foregroundStyle(.white)
+                                            .padding(.horizontal, 6)
+                                            .padding(.vertical, 2)
+                                            .background(Capsule().fill(.white.opacity(0.3)))
+                                    }
                                 }
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 12)
@@ -79,7 +81,7 @@ extension Contact {
                                 .clipShape(RoundedRectangle(cornerRadius: 14))
                             }
                         } else {
-                            ComposeHeroV2(identifier: self.identifier)
+                            ComposeHeroV2(vm: self.composeVM, identifier: self.identifier)
                         }
 
                         Text(self.profile?.encryptionSchemeLabel ?? "")
@@ -112,8 +114,22 @@ extension Contact {
                     }
                 }
             }
+            .task { self.composeVM.setup(contactManager: self.contactManager) }
+            .onChange(of: self.useThreadCompose) { _, _ in self.composeVM.clearAfterEncrypt() }
+            .onDisappear { self.composeVM.cleanup() }
             .fullScreenCover(isPresented: self.$editing) {
                 Contact.FormV2(mode: .edit(identifier: self.identifier)) { self.dismiss() }
+            }
+            .sheet(item: self.$composeVM.encryptedURL) { url in
+                ActivityView(activityItems: [url], onComplete: { completed in
+                    try? FileManager.default.removeItem(at: url)
+                    if completed { self.composeVM.clearAfterEncrypt() }
+                })
+            }
+            .alert("Error", isPresented: self.$composeVM.isShowingError) {
+                Button("OK") { }
+            } message: {
+                Text(self.composeVM.errorMessage)
             }
         }
     }
@@ -238,6 +254,7 @@ private struct StatusChipV2: View {
 // MARK: - Compose Hero
 
 private struct ComposeHeroV2: View {
+    @Bindable var vm: ComposeViewModel
     let identifier: String
 
     @Environment(ContactManager.self) private var contactManager
@@ -246,33 +263,29 @@ private struct ComposeHeroV2: View {
 
     @Query private var contacts: [Contact.Profile]
 
-    init(identifier: String) {
+    @State private var showMediaPicker = false
+    @State private var showFilePicker  = false
+
+    init(vm: ComposeViewModel, identifier: String) {
+        self.vm = vm
         self.identifier = identifier
-        self._contacts = Query(filter: #Predicate { $0.identifier == identifier })
+        let id = identifier
+        self._contacts = Query(filter: #Predicate { $0.identifier == id })
     }
 
     private var firstName: String { self.contacts.first?.givenName.decrypt() ?? "" }
 
-    @State private var messageText = ""
-    @State private var attachments: [Occulta.File] = []
-    @State private var showMediaPicker = false
-    @State private var showFilePicker = false
-    @State private var encryptedURL: URL?
-    @State private var isShowingError = false
-    @State private var errorMessage = ""
-
     private var isV4: Bool { self.contacts.first?.maxBundleVersion != nil }
 
     private var estimatedBundleSize: Int {
-        let textBytes = self.messageText.utf8.count
-        let fileBytes = self.attachments.reduce(0) { acc, file in
-            guard let url = file.url,
+        let textBytes = self.vm.draftText.utf8.count
+        let fileBytes = self.vm.messages.reduce(0) { acc, file in
+            guard let url  = file.url,
                   let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize
             else { return acc }
             return acc + size
         }
-        // 195 = 167-byte binary header + 28-byte AES-GCM overhead; 80 bytes per-file metadata JSON
-        let raw = max(195, textBytes + fileBytes + 195 + self.attachments.count * 80)
+        let raw = max(195, textBytes + fileBytes + 195 + self.vm.messages.count * 80)
         return self.isV4 ? raw : Int(Double(raw) * 2.37)
     }
 
@@ -281,8 +294,8 @@ private struct ComposeHeroV2: View {
     }
 
     private var canEncrypt: Bool {
-        !self.messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        || !self.attachments.isEmpty
+        !self.vm.draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !self.vm.messages.isEmpty
     }
 
     var body: some View {
@@ -296,18 +309,20 @@ private struct ComposeHeroV2: View {
             }
             .padding(.bottom, 10)
 
-            TextField("", text: self.$messageText, axis: .vertical)
+            TextField("", text: self.$vm.draftText, axis: .vertical)
                 .lineLimit(4...)
-                .frame(minHeight: self.attachments.isEmpty ? 100 : 60, alignment: .topLeading)
+                .frame(minHeight: self.vm.messages.isEmpty ? 100 : 60, alignment: .topLeading)
                 .tint(.occultaAccent)
 
-            // Attachment chips
-            if !self.attachments.isEmpty {
+            let fileItems = self.vm.messages
+                .filter { if case .file = $0.format { return true }; return false }
+                .sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
+            if !fileItems.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 6) {
-                        ForEach(self.attachments) { file in
+                        ForEach(fileItems) { file in
                             AttachmentChipV2(file: file) {
-                                self.attachments.removeAll { $0.id == file.id }
+                                self.vm.deleteMessage(file)
                             }
                         }
                     }
@@ -315,19 +330,15 @@ private struct ComposeHeroV2: View {
                 }
             }
 
-            Divider().padding(.top, self.attachments.isEmpty ? 10 : 2)
+            Divider().padding(.top, self.vm.messages.isEmpty ? 10 : 2)
 
             HStack {
                 HStack(spacing: 10) {
                     Menu {
-                        Button {
-                            self.showMediaPicker = true
-                        } label: {
+                        Button { self.showMediaPicker = true } label: {
                             Label("Photos & Videos", systemImage: "photo")
                         }
-                        Button {
-                            self.showFilePicker = true
-                        } label: {
+                        Button { self.showFilePicker = true } label: {
                             Label("Browse Files", systemImage: "folder")
                         }
                     } label: {
@@ -345,7 +356,6 @@ private struct ComposeHeroV2: View {
 
                     HStack(spacing: 6) {
                         Circle().fill(Color.occultaVerified).frame(width: 6, height: 6)
-
                         Text("~\(self.estimatedBundleSizeLabel)")
                             .font(.system(size: 10, weight: .regular, design: .monospaced))
                             .foregroundStyle(.secondary)
@@ -354,7 +364,7 @@ private struct ComposeHeroV2: View {
                     }
                 }
                 Spacer()
-                Button(action: self.encrypt) {
+                Button(action: self.encryptAction) {
                     Text("Encrypt")
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(self.canEncrypt ? .white : .secondary)
@@ -372,154 +382,23 @@ private struct ComposeHeroV2: View {
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .sheet(isPresented: self.$showMediaPicker) {
             PHPickerRepresentable(isPresented: self.$showMediaPicker) { results in
-                results.forEach { result in Task { await self.handleMedia(result) } }
+                results.forEach { result in Task { await self.vm.handleMedia(result) } }
             }
         }
-        .fileImporter(isPresented: self.$showFilePicker,
-                      allowedContentTypes: [.data],
-                      allowsMultipleSelection: false) { result in
-            self.handleFile(result)
-        }
-        .sheet(item: self.$encryptedURL) { url in
-            ActivityView(activityItems: [url], onComplete: { completed in
-                try? FileManager.default.removeItem(at: url)
-                if completed {
-                    for attachment in self.attachments {
-                        if let stagingURL = attachment.url { try? FileManager.default.removeItem(at: stagingURL) }
-                    }
-                    self.messageText = ""
-                    self.attachments = []
-                }
-            })
-        }
-        .alert("Error", isPresented: self.$isShowingError) {
-            Button("OK") { }
-        } message: {
-            Text(self.errorMessage)
-        }
-        .onDisappear {
-            for attachment in self.attachments {
-                if let url = attachment.url { try? FileManager.default.removeItem(at: url) }
-            }
+        .fileImporter(
+            isPresented: self.$showFilePicker,
+            allowedContentTypes: [.data],
+            allowsMultipleSelection: false
+        ) { result in
+            self.vm.handleFile(result)
         }
     }
 
-    private func handleMedia(_ result: PHPickerResult) async {
-        do {
-            let provider = result.itemProvider
-            let typeID   = provider.registeredTypeIdentifiers.first ?? UTType.data.identifier
-            let ext      = UTType(typeID)?.preferredFilenameExtension ?? "bin"
-            let name     = "media_\(UUID().uuidString.prefix(8))"
-            let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
-            let data: Data = try await withCheckedThrowingContinuation { cont in
-                provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, error in
-                    if let data { cont.resume(returning: data) }
-                    else { cont.resume(throwing: error ?? NSError(domain: "MediaImport", code: 0)) }
-                }
-            }
-            try data.writeProtected(to: url)
-            let file = Occulta.File(url: url, format: .file(.init(name: name, extension: ext)), date: Date())
-            await MainActor.run { self.attachments.append(file) }
-        } catch {
-            self.showError(error.localizedDescription)
-        }
-    }
-
-    private func handleFile(_ result: Result<[URL], Error>) {
-        Task {
-            do {
-                guard let url = try result.get().first,
-                      url.startAccessingSecurityScopedResource() else { return }
-                defer { url.stopAccessingSecurityScopedResource() }
-                let data = try await URLSession.shared.data(from: url).0
-                let name = url.deletingPathExtension().lastPathComponent
-                let ext  = url.pathExtension
-                let tmp  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
-                try data.writeProtected(to: tmp)
-                let file = Occulta.File(url: tmp, format: .file(.init(name: name, extension: ext)), date: Date())
-                await MainActor.run { self.attachments.append(file) }
-            } catch {
-                self.showError(error.localizedDescription)
-            }
-        }
-    }
-
-    private func encrypt() {
-        Task {
-            do {
-                var files: [Occulta.File] = []
-
-                // Text message (optional when attachments present)
-                let text = self.messageText.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !text.isEmpty {
-                    files.append(Occulta.File(content: text.data(using: .utf8), format: .text, date: Date()))
-                }
-
-                // Resolve URL-based attachments to inline data
-                for attachment in self.attachments {
-                    if let url = attachment.url {
-                        let (data, _) = try await URLSession.shared.data(from: url)
-                        files.append(Occulta.File(content: data, format: attachment.format, date: attachment.date))
-                    } else {
-                        files.append(attachment)
-                    }
-                }
-
-                let basket  = Basket(files: files)
-
-                let contactPub = try? self.contactManager.currentPublicKey(forIdentifier: self.identifier)
-                let shardOps   = try self.shardCustodyManager?.buildShardOperations(for: self.identifier, currentContactPublicKey: contactPub) ?? []
-                let manifest_  = try? self.shardCustodyManager?.buildCustodyManifest(for: self.identifier)
-                let expected   = try? self.shardCustodyManager.flatMap { try $0.buildExpectedShards(for: self.identifier, vaultManager: self.vaultManager!) }
-
-                #if DEBUG
-                debugPrint("Manifest: \(manifest_?.description ?? "nil")")
-                debugPrint("Expected: \(expected?.description ?? "nil")")
-                debugPrint("Shard ops: \(shardOps.isEmpty ? "none" : shardOps.map(\.kind.rawValue).joined(separator: "\n"))")
-                #endif
-
-                let encrypted: Data
-                do {
-                    encrypted = try self.contactManager.encryptBundle(
-                        basket:          basket,
-                        for:             identifier,
-                        shardOperations: shardOps.isEmpty ? nil : shardOps,
-                        custodyManifest: manifest_,
-                        expectedShards:  expected
-                    )
-                } catch ContactManager.Errors.trusteeLacksQuantumMaterial {
-                    // Quantum material corrupted or missing — fall back to classical,
-                    // strip shard ops (they stay pending and will retry after re-exchange).
-                    encrypted = try self.contactManager.encryptBundle(
-                        basket: basket,
-                        for:    identifier
-                    )
-                } catch {
-                    encrypted = Data()
-                }
-
-                guard !encrypted.isEmpty else {
-                    self.showError("Encryption failed. Try again.")
-                    return
-                }
-
-                let name = UUID().uuidString.components(separatedBy: "-").last ?? "msg"
-                let url  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).occ")
-                try encrypted.writeProtected(to: url)
-
-                await MainActor.run {
-                    self.encryptedURL = url
-                }
-            } catch {
-                self.showError(error.localizedDescription)
-            }
-        }
-    }
-
-    @MainActor
-    private func showError(_ message: String) {
-        self.errorMessage = message
-        self.isShowingError = true
+    private func encryptAction() {
+        let cm  = self.contactManager
+        let scm = self.shardCustodyManager
+        let vlt = self.vaultManager
+        Task { await self.vm.encrypt(contactManager: cm, shardCustodyManager: scm, vaultManager: vlt) }
     }
 }
 
@@ -529,12 +408,26 @@ private struct AttachmentChipV2: View {
     let file: Occulta.File
     let onRemove: () -> Void
 
-    private var name: String {
-        guard case .file(let meta) = self.file.format else { return "file" }
-        return [meta.name, meta.extension].compactMap { $0 }.joined(separator: ".")
+    private var isText: Bool {
+        if case .text = self.file.format { return true }
+        return false
+    }
+
+    private var label: String {
+        switch self.file.format {
+        case .text:
+            guard let data = self.file.content, let str = String(data: data, encoding: .utf8) else { return "text" }
+            let truncated = str.trimmingCharacters(in: .whitespacesAndNewlines)
+            return truncated.count > 28 ? String(truncated.prefix(28)) + "…" : truncated
+        case .file(let meta):
+            return [meta.name, meta.extension].compactMap { $0 }.joined(separator: ".")
+        default:
+            return "file"
+        }
     }
 
     private var sfSymbol: String {
+        if self.isText { return "paragraph" }
         guard case .file(let meta) = self.file.format else { return "doc" }
         switch meta.extension?.lowercased() {
         case "jpg", "jpeg", "png", "heic": return "photo"
@@ -544,7 +437,8 @@ private struct AttachmentChipV2: View {
     }
 
     private var sizeLabel: String? {
-        guard let url = self.file.url,
+        guard !self.isText,
+              let url  = self.file.url,
               let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize
         else { return nil }
         return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
@@ -560,7 +454,7 @@ private struct AttachmentChipV2: View {
                     .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(.white)
             }
-            Text(self.name)
+            Text(self.label)
                 .font(.system(size: 11, weight: .regular, design: .monospaced))
                 .lineLimit(1)
             if let size = self.sizeLabel {

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -24,7 +24,6 @@ extension Contact {
         // Thread compose state — persists while this contact detail is on the stack
         @State private var threadMessages: [Occulta.File] = []
         @State private var threadMessageText = ""
-        @State private var threadSelectedMedia: [PhotosPickerItem] = []
 
         init(identifier: String) {
             self.identifier = identifier
@@ -67,8 +66,7 @@ extension Contact {
                             NavigationLink(destination: ComposableMessage(
                                 identifier: self.identifier,
                                 messages: self.$threadMessages,
-                                messageText: self.$threadMessageText,
-                                selectedMediaItems: self.$threadSelectedMedia
+                                messageText: self.$threadMessageText
                             )) {
                                 HStack {
                                     Text("Open thread")
@@ -257,7 +255,6 @@ private struct ComposeHeroV2: View {
 
     @State private var messageText = ""
     @State private var attachments: [Occulta.File] = []
-    @State private var selectedMediaItems: [PhotosPickerItem] = []
     @State private var showMediaPicker = false
     @State private var showFilePicker = false
     @State private var encryptedURL: URL?
@@ -373,10 +370,10 @@ private struct ComposeHeroV2: View {
         .padding(14)
         .background(Color(.secondarySystemGroupedBackground))
         .clipShape(RoundedRectangle(cornerRadius: 14))
-        .photosPicker(isPresented: self.$showMediaPicker, selection: self.$selectedMediaItems,
-                      matching: .any(of: [.images, .videos]))
-        .onChange(of: self.selectedMediaItems) { _, newItems in
-            newItems.forEach { item in Task { await self.handleMedia(item) } }
+        .sheet(isPresented: self.$showMediaPicker) {
+            PHPickerRepresentable(isPresented: self.$showMediaPicker) { results in
+                results.forEach { result in Task { await self.handleMedia(result) } }
+            }
         }
         .fileImporter(isPresented: self.$showFilePicker,
                       allowedContentTypes: [.data],
@@ -392,7 +389,6 @@ private struct ComposeHeroV2: View {
                     }
                     self.messageText = ""
                     self.attachments = []
-                    self.selectedMediaItems = []
                 }
             })
         }
@@ -408,12 +404,19 @@ private struct ComposeHeroV2: View {
         }
     }
 
-    private func handleMedia(_ item: PhotosPickerItem) async {
+    private func handleMedia(_ result: PHPickerResult) async {
         do {
-            guard let data = try await item.loadTransferable(type: Data.self) else { return }
-            let ext  = item.supportedContentTypes.first?.preferredFilenameExtension ?? "bin"
-            let name = "media_\(UUID().uuidString.prefix(8))"
-            let url  = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
+            let provider = result.itemProvider
+            let typeID   = provider.registeredTypeIdentifiers.first ?? UTType.data.identifier
+            let ext      = UTType(typeID)?.preferredFilenameExtension ?? "bin"
+            let name     = "media_\(UUID().uuidString.prefix(8))"
+            let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(name).\(ext)")
+            let data: Data = try await withCheckedThrowingContinuation { cont in
+                provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, error in
+                    if let data { cont.resume(returning: data) }
+                    else { cont.resume(throwing: error ?? NSError(domain: "MediaImport", code: 0)) }
+                }
+            }
             try data.writeProtected(to: url)
             let file = Occulta.File(url: url, format: .file(.init(name: name, extension: ext)), date: Date())
             await MainActor.run { self.attachments.append(file) }

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -55,7 +55,7 @@ extension Contact {
                     if self.needsExchange {
                         ExchangeHeroV2(identifier: self.identifier)
                     } else {
-                        ComposeHeroV2(identifier: self.identifier, firstName: self.givenName)
+                        ComposeHeroV2(identifier: self.identifier)
 
                         Text(self.profile?.encryptionSchemeLabel ?? "")
                             .font(.system(size: 10, weight: .regular, design: .monospaced))
@@ -171,12 +171,20 @@ private struct StatusChipV2: View {
 
 private struct ComposeHeroV2: View {
     let identifier: String
-    let firstName: String
 
     @Environment(ContactManager.self) private var contactManager
     @Environment(ShardCustodyManager.self) private var shardCustodyManager: ShardCustodyManager?
     @Environment(VaultManager.self) private var vaultManager: VaultManager?
-    
+
+    @Query private var contacts: [Contact.Profile]
+
+    init(identifier: String) {
+        self.identifier = identifier
+        self._contacts = Query(filter: #Predicate { $0.identifier == identifier })
+    }
+
+    private var firstName: String { self.contacts.first?.givenName.decrypt() ?? "" }
+
     @State private var messageText = ""
     @State private var attachments: [Occulta.File] = []
     @State private var selectedMediaItems: [PhotosPickerItem] = []
@@ -186,9 +194,25 @@ private struct ComposeHeroV2: View {
     @State private var isShowingError = false
     @State private var errorMessage = ""
 
-    private var ciphertextEstimate: Int {
-        max(256, self.messageText.count * 4 + 256 + self.attachments.count * 1024)
+    private var isV4: Bool { self.contacts.first?.maxBundleVersion != nil }
+
+    private var estimatedBundleSize: Int {
+        let textBytes = self.messageText.utf8.count
+        let fileBytes = self.attachments.reduce(0) { acc, file in
+            guard let url = file.url,
+                  let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize
+            else { return acc }
+            return acc + size
+        }
+        // 195 = 167-byte binary header + 28-byte AES-GCM overhead; 80 bytes per-file metadata JSON
+        let raw = max(195, textBytes + fileBytes + 195 + self.attachments.count * 80)
+        return self.isV4 ? raw : Int(Double(raw) * 2.37)
     }
+
+    private var estimatedBundleSizeLabel: String {
+        ByteCountFormatter.string(fromByteCount: Int64(self.estimatedBundleSize), countStyle: .file)
+    }
+
     private var canEncrypt: Bool {
         !self.messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         || !self.attachments.isEmpty
@@ -254,10 +278,12 @@ private struct ComposeHeroV2: View {
 
                     HStack(spacing: 6) {
                         Circle().fill(Color.occultaVerified).frame(width: 6, height: 6)
-                        
-                        Text("ciphertext · \(self.ciphertextEstimate) bytes")
+
+                        Text("~\(self.estimatedBundleSizeLabel)")
                             .font(.system(size: 10, weight: .regular, design: .monospaced))
                             .foregroundStyle(.secondary)
+                            .contentTransition(.numericText())
+                            .animation(.easeInOut(duration: 0.2), value: self.estimatedBundleSize)
                     }
                 }
                 Spacer()

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -22,6 +22,13 @@ extension Contact {
         @State private var displayingVerificationInfo = false
         @State private var useThreadCompose = false
 
+        // Thread compose state — persists while this contact detail is on the stack
+        @State private var threadMessages: [Occulta.File] = []
+        @State private var threadMessageText = ""
+        @State private var threadThumbnails: [UUID: Data] = [:]
+        @State private var threadSessionKey = SymmetricKey(size: .bits256)
+        @State private var threadSelectedMedia: [PhotosPickerItem] = []
+
         init(identifier: String) {
             self.identifier = identifier
             self._contacts = Query(filter: #Predicate { $0.identifier == identifier })
@@ -60,7 +67,14 @@ extension Contact {
                         ComposeStyleToggle(useThread: self.$useThreadCompose)
 
                         if self.useThreadCompose {
-                            NavigationLink(destination: ComposableMessage(identifier: self.identifier)) {
+                            NavigationLink(destination: ComposableMessage(
+                                identifier: self.identifier,
+                                sessionKey: self.threadSessionKey,
+                                messages: self.$threadMessages,
+                                messageText: self.$threadMessageText,
+                                thumbnails: self.$threadThumbnails,
+                                selectedMediaItems: self.$threadSelectedMedia
+                            )) {
                                 HStack {
                                     Text("Open thread")
                                         .font(.system(size: 14, weight: .semibold))

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -19,6 +19,7 @@ extension Contact {
         @State private var editing = false
         @State private var keyDetailsExpanded = false
         @State private var displayingVerificationInfo = false
+        @State private var useThreadCompose = false
 
         init(identifier: String) {
             self.identifier = identifier
@@ -55,7 +56,23 @@ extension Contact {
                     if self.needsExchange {
                         ExchangeHeroV2(identifier: self.identifier)
                     } else {
-                        ComposeHeroV2(identifier: self.identifier)
+                        ComposeStyleToggle(useThread: self.$useThreadCompose)
+
+                        if self.useThreadCompose {
+                            NavigationLink(destination: ComposableMessage(identifier: self.identifier)) {
+                                HStack {
+                                    Text("Open thread")
+                                        .font(.system(size: 14, weight: .semibold))
+                                        .foregroundStyle(.white)
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                                .background(Color.occultaAccent)
+                                .clipShape(RoundedRectangle(cornerRadius: 14))
+                            }
+                        } else {
+                            ComposeHeroV2(identifier: self.identifier)
+                        }
 
                         Text(self.profile?.encryptionSchemeLabel ?? "")
                             .font(.system(size: 10, weight: .regular, design: .monospaced))
@@ -90,6 +107,49 @@ extension Contact {
             .fullScreenCover(isPresented: self.$editing) {
                 Contact.FormV2(mode: .edit(identifier: self.identifier)) { self.dismiss() }
             }
+        }
+    }
+}
+
+// MARK: - Compose Style Toggle
+
+private struct ComposeStyleToggle: View {
+    @Binding var useThread: Bool
+
+    var body: some View {
+        HStack {
+            Text("compose style")
+                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) { self.useThread.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    if self.useThread {
+                        Circle()
+                            .fill(Color.occultaAccent)
+                            .frame(width: 8, height: 8)
+                        Text("Thread")
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(Color.occultaAccent)
+                    } else {
+                        Circle()
+                            .strokeBorder(Color(.separator), lineWidth: 1.5)
+                            .frame(width: 8, height: 8)
+                        Text("Quick")
+                            .font(.system(size: 11, weight: .regular, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(Color(.tertiarySystemFill))
+                .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
         }
     }
 }

--- a/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
+++ b/Occulta/UI/Tabs/Contacts/V2/ContactDetailV2.swift
@@ -402,7 +402,9 @@ private struct ComposeHeroV2: View {
             Text(self.errorMessage)
         }
         .onDisappear {
-            FileManager.default.clearTemporaryDirectory()
+            for attachment in self.attachments {
+                if let url = attachment.url { try? FileManager.default.removeItem(at: url) }
+            }
         }
     }
 

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -19,31 +19,37 @@ struct ComposableMessage: View {
     
     @Query(Contact.Profile.descriptor) var contacts: [Contact.Profile]
 
-    init(identifier: String) {
-        self.identifier = identifier
-        
-        let predicate = #Predicate<Contact.Profile> {
-            $0.identifier == identifier
-        }
-        
-        self._contacts = Query(filter: predicate)
-    }
-    
-    @State private var messages: [Occulta.File] = []
-    @State private var messageText: String = ""
-    @State private var sessionKey = SymmetricKey(size: .bits256)
-    @State private var thumbnails: [UUID: Data] = [:]
+    @Binding var messages: [Occulta.File]
+    @Binding var messageText: String
+    let sessionKey: SymmetricKey
+    @Binding var thumbnails: [UUID: Data]
+    @Binding var selectedMediaItems: [PhotosPickerItem]
 
-    // Picker states
+    // Local UI state
     @State private var showMediaPicker = false
     @State private var showFileImporter = false
-    @State private var selectedMediaItems: [PhotosPickerItem] = []
-    /// Encrypted conversation
     @State private var encryptedResultURL: URL?
-
-    // Error feedback
     @State private var showError = false
     @State private var errorMessage = ""
+
+    init(
+        identifier: String,
+        sessionKey: SymmetricKey,
+        messages: Binding<[Occulta.File]>,
+        messageText: Binding<String>,
+        thumbnails: Binding<[UUID: Data]>,
+        selectedMediaItems: Binding<[PhotosPickerItem]>
+    ) {
+        self.identifier = identifier
+        self.sessionKey = sessionKey
+        self._messages = messages
+        self._messageText = messageText
+        self._thumbnails = thumbnails
+        self._selectedMediaItems = selectedMediaItems
+
+        let predicate = #Predicate<Contact.Profile> { $0.identifier == identifier }
+        self._contacts = Query(filter: predicate)
+    }
     
     var body: some View {
         VStack {
@@ -703,10 +709,26 @@ struct FileExtensions {
 // MARK: - Preview
 
 #Preview {
-    NavigationStack {
-        ComposableMessage(identifier: UUID().uuidString)
-            .environment(ContactManager.preview)
+    struct Preview: View {
+        @State var messages: [Occulta.File] = []
+        @State var text = ""
+        @State var thumbs: [UUID: Data] = [:]
+        @State var selected: [PhotosPickerItem] = []
+        var body: some View {
+            NavigationStack {
+                ComposableMessage(
+                    identifier: UUID().uuidString,
+                    sessionKey: SymmetricKey(size: .bits256),
+                    messages: self.$messages,
+                    messageText: self.$text,
+                    thumbnails: self.$thumbs,
+                    selectedMediaItems: self.$selected
+                )
+                .environment(ContactManager.preview)
+            }
+        }
     }
+    return Preview()
 }
 
 #Preview {

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -449,7 +449,7 @@ struct ComposableMessage: View {
             let ext      = contentType.preferredFilenameExtension ?? "bin"
             let filename = "media_\(UUID().uuidString.prefix(8))"
             let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-            try data.write(to: url)
+            try data.write(to: url, options: .completeFileProtection)
             let file = Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date())
             await MainActor.run { self.messages.append(file) }
         } catch {
@@ -469,7 +469,7 @@ struct ComposableMessage: View {
                 let filename = url.deletingPathExtension().lastPathComponent
                 let ext      = url.pathExtension
                 let tmp      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-                try data.write(to: tmp)
+                try data.write(to: tmp, options: .completeFileProtection)
                 let file = Occulta.File(url: tmp, format: .file(.init(name: filename, extension: ext)), date: Date())
                 await MainActor.run { self.messages.append(file) }
             } catch {
@@ -541,7 +541,7 @@ struct ComposableMessage: View {
                 let tempURL = FileManager.default.temporaryDirectory
                     .appendingPathComponent("\(id).occ")
                 
-                try encrypted.write(to: tempURL)
+                try encrypted.write(to: tempURL, options: .completeFileProtection)
                 
                 await MainActor.run {
                     self.encryptedResultURL = tempURL

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -3,7 +3,6 @@ import SwiftData
 import UniformTypeIdentifiers
 import PhotosUI
 import AVKit
-import CryptoKit
 
 extension URL: @retroactive Identifiable {
     public var id: String { absoluteString }
@@ -21,8 +20,6 @@ struct ComposableMessage: View {
 
     @Binding var messages: [Occulta.File]
     @Binding var messageText: String
-    let sessionKey: SymmetricKey
-    @Binding var thumbnails: [UUID: Data]
     @Binding var selectedMediaItems: [PhotosPickerItem]
 
     // Local UI state
@@ -34,17 +31,13 @@ struct ComposableMessage: View {
 
     init(
         identifier: String,
-        sessionKey: SymmetricKey,
         messages: Binding<[Occulta.File]>,
         messageText: Binding<String>,
-        thumbnails: Binding<[UUID: Data]>,
         selectedMediaItems: Binding<[PhotosPickerItem]>
     ) {
         self.identifier = identifier
-        self.sessionKey = sessionKey
         self._messages = messages
         self._messageText = messageText
-        self._thumbnails = thumbnails
         self._selectedMediaItems = selectedMediaItems
 
         let predicate = #Predicate<Contact.Profile> { $0.identifier == identifier }
@@ -61,7 +54,7 @@ struct ComposableMessage: View {
                         .multilineTextAlignment(.center)
                 }
             } else {
-                Conversation(mode: .write, messages: self.$messages, thumbnails: self.thumbnails)
+                Conversation(mode: .write, messages: self.$messages)
             }
             
             HStack(alignment: .center, spacing: 10) {
@@ -122,7 +115,6 @@ struct ComposableMessage: View {
                             }
                             self.messages = []
                             self.selectedMediaItems = []
-                            self.thumbnails = [:]
                         }
                     })
                 }
@@ -151,7 +143,6 @@ struct ComposableMessage: View {
     struct Conversation: View {
         let mode: Modes
         @Binding var messages: [Occulta.File]
-        var thumbnails: [UUID: Data] = [:]
 
         enum Modes {
             case read(messageOwner: String), write
@@ -178,7 +169,7 @@ struct ComposableMessage: View {
                                         DateHeader(date: file.date ?? Date())
                                     }
                                     
-                                    MessageBubble(file: file, mode: self.mode, thumbnail: self.thumbnails[file.id])
+                                    MessageBubble(file: file, mode: self.mode)
                                 }
                                 .id(file.id)
                             }
@@ -229,7 +220,6 @@ struct ComposableMessage: View {
         struct MessageBubble: View {
             let file: Occulta.File
             let mode: Conversation.Modes
-            var thumbnail: Data? = nil
 
             @State private var showingFullScreen = false
             @Environment(\.colorScheme) private var colorScheme
@@ -298,35 +288,25 @@ struct ComposableMessage: View {
                     let name = metadata.name ?? "file"
                     if let _ = FileExtensions.Image(rawValue: metadata.extension ?? "") {
                         VStack(spacing: 6) {
-                            Group {
-                                if case .write = self.mode, let thumbData = self.thumbnail, let img = UIImage(data: thumbData) {
-                                    Image(uiImage: img)
-                                        .resizable()
-                                        .scaledToFill()
-                                        .frame(maxWidth: 260, maxHeight: 320)
-                                        .clipShape(RoundedRectangle(cornerRadius: 18))
-                                } else {
-                                    AsyncImage(url: self.file.url) { phase in
-                                        switch phase {
-                                        case .success(let image):
-                                            image.resizable().scaledToFill()
-                                        case .failure(let error):
-                                            VStack(spacing: 4) {
-                                                Image(systemName: "exclamationmark.triangle").foregroundStyle(.secondary)
-                                                Text(error.localizedDescription).font(.caption2).foregroundStyle(.secondary).multilineTextAlignment(.center)
-                                            }
-                                        case .empty: ProgressView()
-                                        @unknown default: ProgressView()
-                                        }
+                            AsyncImage(url: self.file.url) { phase in
+                                switch phase {
+                                case .success(let image):
+                                    image.resizable().scaledToFill()
+                                case .failure(let error):
+                                    VStack(spacing: 4) {
+                                        Image(systemName: "exclamationmark.triangle").foregroundStyle(.secondary)
+                                        Text(error.localizedDescription).font(.caption2).foregroundStyle(.secondary).multilineTextAlignment(.center)
                                     }
-                                    .frame(maxWidth: 260, maxHeight: 320)
-                                    .clipShape(RoundedRectangle(cornerRadius: 18))
-                                    .onTapGesture { self.showingFullScreen = true }
-                                    .contextMenu {
-                                        if case .read = self.mode, let url = self.file.url {
-                                            ShareLink(item: url) { Label("Share", systemImage: "square.and.arrow.up") }
-                                        }
-                                    }
+                                case .empty: ProgressView()
+                                @unknown default: ProgressView()
+                                }
+                            }
+                            .frame(maxWidth: 260, maxHeight: 320)
+                            .clipShape(RoundedRectangle(cornerRadius: 18))
+                            .onTapGesture { self.showingFullScreen = true }
+                            .contextMenu {
+                                if case .read = self.mode, let url = self.file.url {
+                                    ShareLink(item: url) { Label("Share", systemImage: "square.and.arrow.up") }
                                 }
                             }
 
@@ -354,9 +334,7 @@ struct ComposableMessage: View {
                             }
                             .frame(width: 260, height: 200)
                             .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .onTapGesture {
-                                if case .read = self.mode { self.showingFullScreen = true }
-                            }
+                            .onTapGesture { self.showingFullScreen = true }
                             .contextMenu {
                                 if case .read = self.mode {
                                     ShareLink(item: url) {
@@ -470,21 +448,10 @@ struct ComposableMessage: View {
             let contentType = item.supportedContentTypes.first ?? .data
             let ext      = contentType.preferredFilenameExtension ?? "bin"
             let filename = "media_\(UUID().uuidString.prefix(8))"
-
-            var thumb: Data? = nil
-            if let _ = FileExtensions.Image(rawValue: ext), let img = UIImage(data: data) {
-                thumb = img.preparingThumbnail(of: CGSize(width: 520, height: 640))?.jpegData(compressionQuality: 0.7)
-            }
-
-            let encrypted = try AES.GCM.seal(data, using: self.sessionKey).combined!
-            let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-            try encrypted.write(to: url)
-
+            let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
+            try data.write(to: url)
             let file = Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date())
-            await MainActor.run {
-                if let thumb { self.thumbnails[file.id] = thumb }
-                self.messages.append(file)
-            }
+            await MainActor.run { self.messages.append(file) }
         } catch {
             self.showErrorAlert(error.localizedDescription)
         }
@@ -498,12 +465,11 @@ struct ComposableMessage: View {
                     url.startAccessingSecurityScopedResource()
                 else { return }
                 defer { url.stopAccessingSecurityScopedResource() }
-                let data      = try await URLSession.shared.data(from: url).0
-                let filename  = url.deletingPathExtension().lastPathComponent
-                let ext       = url.pathExtension
-                let encrypted = try AES.GCM.seal(data, using: self.sessionKey).combined!
-                let tmp       = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-                try encrypted.write(to: tmp)
+                let data     = try await URLSession.shared.data(from: url).0
+                let filename = url.deletingPathExtension().lastPathComponent
+                let ext      = url.pathExtension
+                let tmp      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
+                try data.write(to: tmp)
                 let file = Occulta.File(url: tmp, format: .file(.init(name: filename, extension: ext)), date: Date())
                 await MainActor.run { self.messages.append(file) }
             } catch {
@@ -521,9 +487,7 @@ struct ComposableMessage: View {
                 
                 for file in self.messages {
                     if let url = file.url {
-                        let encrypted = try Data(contentsOf: url)
-                        let sealedBox = try AES.GCM.SealedBox(combined: encrypted)
-                        let data      = try AES.GCM.open(sealedBox, using: self.sessionKey)
+                        let (data, _) = try await URLSession.shared.data(from: url)
                         processed.append(Occulta.File(content: data, format: file.format, date: file.date))
                     } else {
                         processed.append(file)
@@ -712,16 +676,13 @@ struct FileExtensions {
     struct Preview: View {
         @State var messages: [Occulta.File] = []
         @State var text = ""
-        @State var thumbs: [UUID: Data] = [:]
         @State var selected: [PhotosPickerItem] = []
         var body: some View {
             NavigationStack {
                 ComposableMessage(
                     identifier: UUID().uuidString,
-                    sessionKey: SymmetricKey(size: .bits256),
                     messages: self.$messages,
                     messageText: self.$text,
-                    thumbnails: self.$thumbs,
                     selectedMediaItems: self.$selected
                 )
                 .environment(ContactManager.preview)

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -337,14 +337,14 @@ struct ComposableMessage: View {
                             HStack(spacing: 4) {
                                 Text(name)
                                     .font(.caption)
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(.primary)
                                 if let size = self.fileSize {
                                     Text("·")
                                         .font(.caption)
-                                        .foregroundStyle(.white.opacity(0.5))
+                                        .foregroundStyle(.secondary)
                                     Text(size)
                                         .font(.caption)
-                                        .foregroundStyle(.white.opacity(0.5))
+                                        .foregroundStyle(.secondary)
                                 }
                             }
                         }
@@ -386,14 +386,14 @@ struct ComposableMessage: View {
                             HStack(spacing: 4) {
                                 Text(name)
                                     .font(.caption)
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(.primary)
                                 if let size = self.fileSize {
                                     Text("·")
                                         .font(.caption)
-                                        .foregroundStyle(.white.opacity(0.5))
+                                        .foregroundStyle(.secondary)
                                     Text(size)
                                         .font(.caption)
-                                        .foregroundStyle(.white.opacity(0.5))
+                                        .foregroundStyle(.secondary)
                                 }
                             }
                         }

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -3,6 +3,7 @@ import SwiftData
 import UniformTypeIdentifiers
 import PhotosUI
 import AVKit
+import CryptoKit
 
 extension URL: @retroactive Identifiable {
     public var id: String { absoluteString }
@@ -29,16 +30,17 @@ struct ComposableMessage: View {
     }
     
     @State private var messages: [Occulta.File] = []
-    
     @State private var messageText: String = ""
-    
+    @State private var sessionKey = SymmetricKey(size: .bits256)
+    @State private var thumbnails: [UUID: Data] = [:]
+
     // Picker states
     @State private var showMediaPicker = false
     @State private var showFileImporter = false
     @State private var selectedMediaItems: [PhotosPickerItem] = []
     /// Encrypted conversation
     @State private var encryptedResultURL: URL?
-    
+
     // Error feedback
     @State private var showError = false
     @State private var errorMessage = ""
@@ -53,7 +55,7 @@ struct ComposableMessage: View {
                         .multilineTextAlignment(.center)
                 }
             } else {
-                Conversation(mode: .write, messages: self.$messages)
+                Conversation(mode: .write, messages: self.$messages, thumbnails: self.thumbnails)
             }
             
             HStack(alignment: .center, spacing: 10) {
@@ -109,8 +111,12 @@ struct ComposableMessage: View {
                     ActivityView(activityItems: [url], onComplete: { completed in
                         try? FileManager.default.removeItem(at: url)
                         if completed {
+                            for file in self.messages {
+                                if let stagingURL = file.url { try? FileManager.default.removeItem(at: stagingURL) }
+                            }
                             self.messages = []
                             self.selectedMediaItems = []
+                            self.thumbnails = [:]
                         }
                     })
                 }
@@ -138,9 +144,9 @@ struct ComposableMessage: View {
     
     struct Conversation: View {
         let mode: Modes
-        
         @Binding var messages: [Occulta.File]
-        
+        var thumbnails: [UUID: Data] = [:]
+
         enum Modes {
             case read(messageOwner: String), write
         }
@@ -166,7 +172,7 @@ struct ComposableMessage: View {
                                         DateHeader(date: file.date ?? Date())
                                     }
                                     
-                                    MessageBubble(file: file, mode: self.mode)
+                                    MessageBubble(file: file, mode: self.mode, thumbnail: self.thumbnails[file.id])
                                 }
                                 .id(file.id)
                             }
@@ -217,6 +223,7 @@ struct ComposableMessage: View {
         struct MessageBubble: View {
             let file: Occulta.File
             let mode: Conversation.Modes
+            var thumbnail: Data? = nil
 
             @State private var showingFullScreen = false
             @Environment(\.colorScheme) private var colorScheme
@@ -285,34 +292,34 @@ struct ComposableMessage: View {
                     let name = metadata.name ?? "file"
                     if let _ = FileExtensions.Image(rawValue: metadata.extension ?? "") {
                         VStack(spacing: 6) {
-                            AsyncImage(url: self.file.url) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image
+                            Group {
+                                if case .write = self.mode, let thumbData = self.thumbnail, let img = UIImage(data: thumbData) {
+                                    Image(uiImage: img)
                                         .resizable()
                                         .scaledToFill()
-                                case .failure(let error):
-                                    VStack(spacing: 4) {
-                                        Image(systemName: "exclamationmark.triangle")
-                                            .foregroundStyle(.secondary)
-                                        Text(error.localizedDescription)
-                                            .font(.caption2)
-                                            .foregroundStyle(.secondary)
-                                            .multilineTextAlignment(.center)
+                                        .frame(maxWidth: 260, maxHeight: 320)
+                                        .clipShape(RoundedRectangle(cornerRadius: 18))
+                                } else {
+                                    AsyncImage(url: self.file.url) { phase in
+                                        switch phase {
+                                        case .success(let image):
+                                            image.resizable().scaledToFill()
+                                        case .failure(let error):
+                                            VStack(spacing: 4) {
+                                                Image(systemName: "exclamationmark.triangle").foregroundStyle(.secondary)
+                                                Text(error.localizedDescription).font(.caption2).foregroundStyle(.secondary).multilineTextAlignment(.center)
+                                            }
+                                        case .empty: ProgressView()
+                                        @unknown default: ProgressView()
+                                        }
                                     }
-                                case .empty:
-                                    ProgressView()
-                                @unknown default:
-                                    ProgressView()
-                                }
-                            }
-                            .frame(maxWidth: 260, maxHeight: 320)
-                            .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .onTapGesture { self.showingFullScreen = true }
-                            .contextMenu {
-                                if case .read = self.mode, let url = self.file.url {
-                                    ShareLink(item: url) {
-                                        Label("Share", systemImage: "square.and.arrow.up")
+                                    .frame(maxWidth: 260, maxHeight: 320)
+                                    .clipShape(RoundedRectangle(cornerRadius: 18))
+                                    .onTapGesture { self.showingFullScreen = true }
+                                    .contextMenu {
+                                        if case .read = self.mode, let url = self.file.url {
+                                            ShareLink(item: url) { Label("Share", systemImage: "square.and.arrow.up") }
+                                        }
                                     }
                                 }
                             }
@@ -341,7 +348,9 @@ struct ComposableMessage: View {
                             }
                             .frame(width: 260, height: 200)
                             .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .onTapGesture { self.showingFullScreen = true }
+                            .onTapGesture {
+                                if case .read = self.mode { self.showingFullScreen = true }
+                            }
                             .contextMenu {
                                 if case .read = self.mode {
                                     ShareLink(item: url) {
@@ -451,28 +460,30 @@ struct ComposableMessage: View {
     
     private func handleMedia(_ item: PhotosPickerItem) async {
         do {
-            guard
-                let data = try await item.loadTransferable(type: Data.self)
-            else { return }
-            
+            guard let data = try await item.loadTransferable(type: Data.self) else { return }
             let contentType = item.supportedContentTypes.first ?? .data
-            let ext = contentType.preferredFilenameExtension ?? "bin"
+            let ext      = contentType.preferredFilenameExtension ?? "bin"
             let filename = "media_\(UUID().uuidString.prefix(8))"
-            
-            let tempDir = FileManager.default.temporaryDirectory
-            let fileURL = tempDir.appendingPathComponent(filename + ".\(ext)")
-            /// We are creating a temp file so that the file data does not stay in memory
-            try data.write(to: fileURL)
-            
-            let metadata = Occulta.File.Metadata(name: filename, extension: ext)
-            let newFile = Occulta.File(url: fileURL, format: .file(metadata), date: Date())
-            
-            self.messages.append(newFile)
+
+            var thumb: Data? = nil
+            if let _ = FileExtensions.Image(rawValue: ext), let img = UIImage(data: data) {
+                thumb = img.preparingThumbnail(of: CGSize(width: 520, height: 640))?.jpegData(compressionQuality: 0.7)
+            }
+
+            let encrypted = try AES.GCM.seal(data, using: self.sessionKey).combined!
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try encrypted.write(to: url)
+
+            let file = Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date())
+            await MainActor.run {
+                if let thumb { self.thumbnails[file.id] = thumb }
+                self.messages.append(file)
+            }
         } catch {
             self.showErrorAlert(error.localizedDescription)
         }
     }
-    
+
     private func handleFile(_ result: Result<[URL], Error>) {
         Task {
             do {
@@ -480,22 +491,15 @@ struct ComposableMessage: View {
                     let url = try result.get().first,
                     url.startAccessingSecurityScopedResource()
                 else { return }
-                
                 defer { url.stopAccessingSecurityScopedResource() }
-                /// Extract data from file.
-                let data = try await URLSession.shared.data(from: url).0
-                /// Create a temp file.
-                let filename = url.lastPathComponent.components(separatedBy: ".").first ?? ""
-                let ext = url.lastPathComponent.components(separatedBy: ".").last ?? ""
-                let tempDir = FileManager.default.temporaryDirectory
-                let tempFileURL = tempDir.appendingPathComponent(filename + ".\(ext)")
-                /// Write to temp file because the original URL is going to have its scope changed back to private.
-                try data.write(to: tempFileURL)
-                
-                let metadata = Occulta.File.Metadata(name: filename, extension: ext)
-                let newFile = Occulta.File(url: tempFileURL, format: .file(metadata), date: Date())
-                
-                self.messages.append(newFile)
+                let data      = try await URLSession.shared.data(from: url).0
+                let filename  = url.deletingPathExtension().lastPathComponent
+                let ext       = url.pathExtension
+                let encrypted = try AES.GCM.seal(data, using: self.sessionKey).combined!
+                let tmp       = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+                try encrypted.write(to: tmp)
+                let file = Occulta.File(url: tmp, format: .file(.init(name: filename, extension: ext)), date: Date())
+                await MainActor.run { self.messages.append(file) }
             } catch {
                 self.showErrorAlert(error.localizedDescription)
             }
@@ -511,19 +515,13 @@ struct ComposableMessage: View {
                 
                 for file in self.messages {
                     if let url = file.url {
-                        /// Messages that only have URLs to the content user imported: photos, videos or other files
-                        /// Using `URLSession` instead of `resourceBytes` because we might need it for brackground processing.
-                        let (data, _) = try await URLSession.shared.data(from: url)
-                        let newFile = Occulta.File(content: data, format: file.format, date: file.date)
-                        processed.append(newFile)
+                        let encrypted = try Data(contentsOf: url)
+                        let sealedBox = try AES.GCM.SealedBox(combined: encrypted)
+                        let data      = try AES.GCM.open(sealedBox, using: self.sessionKey)
+                        processed.append(Occulta.File(content: data, format: file.format, date: file.date))
                     } else {
                         processed.append(file)
                     }
-                }
-                
-                // Staging files have been read into `processed` — delete them now
-                for file in self.messages {
-                    if let url = file.url { try? FileManager.default.removeItem(at: url) }
                 }
 
                 // Encode & Encrypt

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -577,7 +577,7 @@ struct ComposableMessage: View {
                 do {
                     encryptedData = try self.contactManager?.encryptBundle(
                         basket:          basket,
-                        for:             identifier,
+                        for:             self.identifier,
                         shardOperations: shardOps.isEmpty ? nil : shardOps,
                         custodyManifest: manifest_,
                         expectedShards:  expected
@@ -587,7 +587,7 @@ struct ComposableMessage: View {
                     // strip shard ops (they stay pending and will retry after re-exchange).
                     encryptedData = try self.contactManager?.encryptBundle(
                         basket: basket,
-                        for:    identifier
+                        for:    self.identifier
                     )
                 } catch {
                     debugPrint("Error: \(error)")

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -518,8 +518,7 @@ struct ComposableMessage: View {
                 // Encode & Encrypt
                 
                 let basket = Basket(files: processed)
-                let encoded = try JSONEncoder().encode(basket)
-                
+
                 let contactPub = try? self.contactManager?.currentPublicKey(forIdentifier: self.identifier)
                 let shardOps   = try self.shardCustodyManager?.buildShardOperations(for: self.identifier, currentContactPublicKey: contactPub) ?? []
                 let manifest_  = try? self.shardCustodyManager?.buildCustodyManifest(for: self.identifier)
@@ -533,7 +532,7 @@ struct ComposableMessage: View {
                 let encryptedData: Data?
                 do {
                     encryptedData = try self.contactManager?.encryptBundle(
-                        data:            encoded,
+                        basket:          basket,
                         for:             identifier,
                         shardOperations: shardOps.isEmpty ? nil : shardOps,
                         custodyManifest: manifest_,
@@ -543,8 +542,8 @@ struct ComposableMessage: View {
                     // Quantum material corrupted or missing — fall back to classical,
                     // strip shard ops (they stay pending and will retry after re-exchange).
                     encryptedData = try self.contactManager?.encryptBundle(
-                        data: encoded,
-                        for:  identifier
+                        basket: basket,
+                        for:    identifier
                     )
                 } catch {
                     debugPrint("Error: \(error)")

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -221,7 +221,7 @@ struct ComposableMessage: View {
             var onDelete: (() -> Void)? = nil
 
             @State private var showingFullScreen = false
-            @State private var videoThumbnail: UIImage? = nil
+            @State private var videoPlayer: AVPlayer? = nil
             @Environment(\.colorScheme) private var colorScheme
 
             var body: some View {
@@ -250,23 +250,12 @@ struct ComposableMessage: View {
                 return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
             }
 
-            private func loadVideoThumbnail(from url: URL) async {
-                let asset = AVURLAsset(url: url)
-                let generator = AVAssetImageGenerator(asset: asset)
-                generator.appliesPreferredTrackTransform = true
-                generator.maximumSize = CGSize(width: 520, height: 400)
-                guard let cgImage = try? await generator.image(at: .zero).image else { return }
-                await MainActor.run { self.videoThumbnail = UIImage(cgImage: cgImage) }
-            }
-
-            @ViewBuilder
+@ViewBuilder
             private var fullScreenContent: some View {
                 switch self.file.format {
                 case .file(let metadata):
                     if let _ = FileExtensions.Image(rawValue: metadata.extension ?? "") {
                         FullScreenImageViewer(url: self.file.url)
-                    } else if let _ = FileExtensions.Video(rawValue: metadata.extension ?? ""), let url = self.file.url {
-                        FullScreenVideoViewer(url: url)
                     }
                 default:
                     EmptyView()
@@ -345,23 +334,17 @@ struct ComposableMessage: View {
                         }
                     } else if let _ = FileExtensions.Video(rawValue: metadata.extension ?? ""), let url = self.file.url {
                         VStack(spacing: 6) {
-                            ZStack {
-                                if let thumbnail = self.videoThumbnail {
-                                    Image(uiImage: thumbnail)
-                                        .resizable()
-                                        .scaledToFill()
+                            Group {
+                                if let player = self.videoPlayer {
+                                    VideoPlayer(player: player)
                                 } else {
                                     Color.black
                                 }
-                                Image(systemName: "play.circle.fill")
-                                    .font(.system(size: 44))
-                                    .foregroundStyle(.white)
-                                    .shadow(radius: 4)
                             }
                             .frame(width: 260, height: 200)
                             .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .onTapGesture { self.showingFullScreen = true }
-                            .task { await self.loadVideoThumbnail(from: url) }
+                            .onAppear { self.videoPlayer = AVPlayer(url: url) }
+                            .onDisappear { self.videoPlayer = nil }
                             .contextMenu {
                                 if case .read = self.mode {
                                     ShareLink(item: url) {
@@ -668,35 +651,6 @@ private struct FullScreenImageViewer: View {
             }
             .padding()
         }
-    }
-}
-
-private struct FullScreenVideoViewer: View {
-    let url: URL
-    @Environment(\.dismiss) private var dismiss
-    @State private var player: AVPlayer
-
-    init(url: URL) {
-        self.url = url
-        self._player = State(initialValue: AVPlayer(url: url))
-    }
-
-    var body: some View {
-        ZStack(alignment: .topTrailing) {
-            Color.black.ignoresSafeArea()
-            VideoPlayer(player: self.player)
-                .ignoresSafeArea()
-            Button { self.dismiss() } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .padding(10)
-                    .background(Circle().fill(.black.opacity(0.5)))
-            }
-            .padding()
-        }
-        .onAppear    { self.player.play() }
-        .onDisappear { self.player.pause() }
     }
 }
 

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -2,60 +2,43 @@ import SwiftUI
 import SwiftData
 import UniformTypeIdentifiers
 import PhotosUI
-import Photos
 import AVKit
 
 extension URL: @retroactive Identifiable {
-    public var id: String { absoluteString }
+    public var id: String { self.absoluteString }
 }
 
-struct PendingImport: Identifiable {
-    let id       = UUID()
-    let filename: String
-    let ext:      String
-    var thumbnail: UIImage? = nil
-    var progress:  Double   = 0
-    var isLoading: Bool     = true
-}
+// MARK: - ComposableMessage
 
 struct ComposableMessage: View {
-    @Environment(ContactManager.self) private var contactManager: ContactManager?
+    @Bindable var vm: ComposeViewModel
+
+    @Query private var contacts: [Contact.Profile]
+    @Environment(ContactManager.self) private var contactManager
     @Environment(ShardCustodyManager.self) private var shardCustodyManager: ShardCustodyManager?
     @Environment(VaultManager.self) private var vaultManager: VaultManager?
-    
-    let identifier: String
-    let filename = "message.occ"
-    
-    @Query(Contact.Profile.descriptor) var contacts: [Contact.Profile]
 
-    @Binding var messages: [Occulta.File]
-    @Binding var messageText: String
-
-    // Local UI state
-    @State private var showMediaPicker = false
+    @State private var showMediaPicker  = false
     @State private var showFileImporter = false
-    @State private var encryptedResultURL: URL?
-    @State private var showError = false
-    @State private var errorMessage = ""
-    @State private var attachmentManager: AttachmentManager? = nil
-    @State private var pendingImports: [PendingImport] = []
 
-    init(
-        identifier: String,
-        messages: Binding<[Occulta.File]>,
-        messageText: Binding<String>
-    ) {
-        self.identifier = identifier
-        self._messages = messages
-        self._messageText = messageText
-
-        let predicate = #Predicate<Contact.Profile> { $0.identifier == identifier }
-        self._contacts = Query(filter: predicate)
+    init(vm: ComposeViewModel) {
+        self.vm = vm
+        let id = vm.identifier
+        self._contacts = Query(filter: #Predicate { $0.identifier == id })
     }
-    
+
+    private var firstName: String {
+        self.contacts.first?.givenName.decrypt() ?? ""
+    }
+
+    private var canEncrypt: Bool {
+        !self.vm.messages.isEmpty
+            || !self.vm.draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var body: some View {
-        VStack {
-            if self.messages.isEmpty && self.pendingImports.isEmpty {
+        VStack(spacing: 0) {
+            if self.vm.messages.isEmpty && self.vm.pendingImports.isEmpty {
                 ContentUnavailableView {
                     Label("Add content", systemImage: "plus.circle")
                 } description: {
@@ -63,9 +46,15 @@ struct ComposableMessage: View {
                         .multilineTextAlignment(.center)
                 }
             } else {
-                Conversation(mode: .write, messages: self.$messages, pendingImports: self.pendingImports, attachmentManager: self.attachmentManager, onDelete: self.deleteMessage)
+                Conversation(
+                    mode: .write,
+                    messages: self.$vm.messages,
+                    pendingImports: self.vm.pendingImports,
+                    attachmentManager: self.vm.attachmentManager,
+                    onDelete: { self.vm.deleteMessage($0) }
+                )
             }
-            
+
             HStack(alignment: .center, spacing: 10) {
                 Menu {
                     Button { self.showMediaPicker = true } label: {
@@ -75,112 +64,126 @@ struct ComposableMessage: View {
                         Label("Browse Files", systemImage: "folder")
                     }
                 } label: {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.system(size: 30))
-                        .foregroundStyle(.blue)
+                    ZStack {
+                        Circle()
+                            .fill(Color(.tertiarySystemFill))
+                            .overlay(Circle().strokeBorder(Color(.separator), lineWidth: 0.5))
+                            .frame(width: 34, height: 34)
+                        Image(systemName: "plus")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(Color.occultaAccent)
+                    }
                 }
-                
-                TextField("Type a message...", text: self.$messageText, axis: .vertical)
-                    .padding(.horizontal, 18)
-                    .padding(.vertical, 11)
+                .tint(.occultaAccent)
+
+                TextField("Type a message...", text: self.$vm.draftText, axis: .vertical)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
                     .background(Color(.systemGray6))
-                    .clipShape(RoundedRectangle(cornerRadius: 24))
-                    .lineLimit(1...6)
-                
-                Button(action: self.addTextMessage) {
-                    Image(systemName: "paperplane.fill")
-                        .foregroundStyle(.white)
-                        .padding(13)
-                        .background(
-                            Circle()
-                                .fill(self.messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                                      ? Color.gray.opacity(0.6)
-                                      : Color.blue)
-                        )
+                    .clipShape(RoundedRectangle(cornerRadius: 22))
+                    .lineLimit(1...5)
+                    .tint(.occultaAccent)
+
+                let hasText = !self.vm.draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                Button { self.vm.addText() } label: {
+                    ZStack {
+                        Circle()
+                            .fill(hasText ? Color.occultaAccent : Color(.tertiarySystemFill))
+                            .frame(width: 34, height: 34)
+                        Image(systemName: "paperplane.fill")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(hasText ? AnyShapeStyle(.white) : AnyShapeStyle(Color.secondary))
+                    }
                 }
-                .disabled(self.messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .disabled(!hasText)
+                .buttonStyle(.plain)
             }
-            .padding(.horizontal, 10)
-            .padding()
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
             .background(Color(.systemBackground))
-            
-            if self.messages.isEmpty == false {
-                Button(action: self.encrypt) {
-                    Label("Encrypt", systemImage: "lock.shield.fill")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.blue)
-                        .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 16))
-                }
-                .padding()
-                .sheet(item: self.$encryptedResultURL) { url in
-                    ActivityView(activityItems: [url], onComplete: { completed in
-                        try? FileManager.default.removeItem(at: url)
-                        if completed {
-                            for file in self.messages {
-                                if let stagingURL = file.url { try? FileManager.default.removeItem(at: stagingURL) }
-                            }
-                            self.messages = []
-                        }
-                    })
-                }
-            }
         }
         .background(Color(.systemGroupedBackground))
-        .sheet(isPresented: self.$showMediaPicker) {
-            PHPickerRepresentable(isPresented: self.$showMediaPicker) { results in
-                results.forEach { result in Task { await self.handleMedia(result) } }
+        .navigationTitle(self.firstName)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: self.encryptAction) {
+                    Text("Encrypt")
+                        .font(.system(size: 13, weight: .semibold))
+                }
+                .disabled(!self.canEncrypt)
+                .tint(.occultaAccent)
             }
         }
-        .fileImporter(isPresented: self.$showFileImporter, allowedContentTypes: [.data], allowsMultipleSelection: false) { result in
-            self.handleFile(result)
+        .sheet(item: self.$vm.encryptedURL) { url in
+            ActivityView(activityItems: [url], onComplete: { completed in
+                try? FileManager.default.removeItem(at: url)
+                if completed { self.vm.clearAfterEncrypt() }
+            })
         }
-        .alert("Error", isPresented: self.$showError) {
+        .alert("Error", isPresented: self.$vm.isShowingError) {
             Button("OK") { }
         } message: {
-            Text(self.errorMessage)
+            Text(self.vm.errorMessage)
         }
-        .task {
-            guard let key = try? self.contactManager?.fileEncryptionKey(for: self.identifier) else { return }
-            self.attachmentManager = AttachmentManager(contactKey: key)
+        .sheet(isPresented: self.$showMediaPicker) {
+            PHPickerRepresentable(isPresented: self.$showMediaPicker) { results in
+                results.forEach { result in Task { await self.vm.handleMedia(result) } }
+            }
+        }
+        .fileImporter(
+            isPresented: self.$showFileImporter,
+            allowedContentTypes: [.data],
+            allowsMultipleSelection: false
+        ) { result in
+            self.vm.handleFile(result)
         }
     }
-    
+
+    private func encryptAction() {
+        let cm  = self.contactManager
+        let scm = self.shardCustodyManager
+        let vlt = self.vaultManager
+        Task { await self.vm.encrypt(contactManager: cm, shardCustodyManager: scm, vaultManager: vlt) }
+    }
+}
+
+// MARK: - Conversation
+
+extension ComposableMessage {
     struct Conversation: View {
         let mode: Modes
         @Binding var messages: [Occulta.File]
-        var pendingImports: [PendingImport] = []
-        var attachmentManager: AttachmentManager? = nil
-        var onDelete: ((Occulta.File) -> Void)? = nil
+        var pendingImports:    [PendingImport]       = []
+        var attachmentManager: AttachmentManager?    = nil
+        var onDelete:          ((Occulta.File) -> Void)? = nil
 
         enum Modes {
             case read(messageOwner: String), write
         }
-        
+
         var body: some View {
             VStack {
-                Group {
-                    switch self.mode {
-                    case .write:
-                        ContactEncryptionDisclaimer()
-                    case .read(let owner):
-                        Contact.Info(identifier: owner)
-                    }
+                if case .read(let owner) = self.mode {
+                    Contact.Info(identifier: owner).padding(.top)
                 }
-                .padding(.top)
-                
+
                 ScrollViewReader { proxy in
                     ScrollView {
                         LazyVStack(alignment: .trailing, spacing: 24) {
                             ForEach(Array(self.messages.enumerated()), id: \.element.id) { index, file in
                                 VStack(spacing: 6) {
-                                    if index == 0 || self.shouldShowDateSeparator(before: self.messages[index - 1], current: file) {
+                                    if index == 0 || self.shouldShowDateSeparator(
+                                        before: self.messages[index - 1], current: file
+                                    ) {
                                         DateHeader(date: file.date ?? Date())
                                     }
-
-                                    MessageBubble(file: file, mode: self.mode, attachmentManager: self.attachmentManager, onDelete: self.onDelete.map { cb in { cb(file) } })
+                                    MessageBubble(
+                                        file: file,
+                                        mode: self.mode,
+                                        attachmentManager: self.attachmentManager,
+                                        onDelete: self.onDelete.map { cb in { cb(file) } }
+                                    )
                                 }
                                 .id(file.id)
                             }
@@ -196,9 +199,7 @@ struct ComposableMessage: View {
                     .scrollDismissesKeyboard(.interactively)
                     .onChange(of: self.messages) { _, latest in
                         withAnimation(.easeOut(duration: 0.3)) {
-                            if let last = latest.last {
-                                proxy.scrollTo(last.id, anchor: .bottom)
-                            }
+                            if let last = latest.last { proxy.scrollTo(last.id, anchor: .bottom) }
                         }
                     }
                     .onChange(of: self.pendingImports.count) { _, _ in
@@ -211,284 +212,80 @@ struct ComposableMessage: View {
                 }
             }
         }
-        
-        private struct ContactEncryptionDisclaimer: View {
-            @State private var displayingInfo: Bool = false
-            
-            var body: some View {
-                VStack {
-                    HStack(alignment: .firstTextBaseline) {
-                        Button {
-                            self.displayingInfo.toggle()
-                        } label: {
-                            Image(systemName: "info.bubble")
-                        }
-                        
-                        Text("Data we encrypt here is only visible to you and this contact.")
-                            .font(.footnote)
-                            .multilineTextAlignment(.center)
-                    }
-                    .padding()
-                    
-                    if self.displayingInfo {
-                        Text("We use **AES GCM 256** encryption, with a key derived from your private key and this contacts public key, to secure data. The key is **never** stored or transmitted anywhere.")
-                            .font(.caption)
-                            .padding()
+
+        private func shouldShowDateSeparator(before: Occulta.File, current: Occulta.File) -> Bool {
+            guard let d1 = before.date, let d2 = current.date else { return false }
+            return !Calendar.current.isDate(d1, inSameDayAs: d2)
+        }
+    }
+}
+
+// MARK: - MessageBubble
+
+extension ComposableMessage {
+    struct MessageBubble: View {
+        let file:              Occulta.File
+        let mode:              Conversation.Modes
+        var attachmentManager: AttachmentManager? = nil
+        var onDelete:          (() -> Void)?      = nil
+
+        @State private var showingFullScreen = false
+        @State private var videoPlayer:    AVPlayer? = nil
+        @State private var decryptedImage: UIImage?  = nil
+        @State private var showingShare = false
+        @Environment(\.colorScheme) private var colorScheme
+
+        var body: some View {
+            HStack(alignment: .center) {
+                Spacer()
+                VStack(alignment: .trailing, spacing: 6) {
+                    self.contentPreview
+                    if let date = self.file.date {
+                        Text(date, format: .dateTime.hour().minute())
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
                     }
                 }
             }
-        }
-        
-        private struct PendingImportBubble: View {
-            let pending: PendingImport
-
-            var body: some View {
-                HStack(alignment: .center) {
-                    Spacer()
-                    VStack(alignment: .trailing, spacing: 6) {
-                        ZStack {
-                            if let thumb = self.pending.thumbnail {
-                                Image(uiImage: thumb)
-                                    .resizable()
-                                    .scaledToFill()
-                                Color.black.opacity(0.4)
-                            } else {
-                                Color.black
-                            }
-                            VStack(spacing: 6) {
-                                ProgressView().tint(.white)
-                                
-                                Text("Loading…")
-                                    .font(.caption2)
-                                    .foregroundStyle(.white)
-                            }
-                        }
-                        .frame(width: 260, height: 200)
-                        .clipShape(RoundedRectangle(cornerRadius: 18))
-
-                        ProgressView(value: self.pending.progress)
-                            .tint(.blue)
-                            .frame(width: 260)
-                            .animation(.linear(duration: 0.1), value: self.pending.progress)
-
-                        HStack(spacing: 4) {
-                            Text(self.pending.filename)
-                                .font(.caption)
-                                .foregroundStyle(.primary)
-                            Text("·")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(self.pending.isLoading ? "Loading…" : "Encrypting…")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-                .padding(.horizontal, 16)
+            .padding(.horizontal, 16)
+            .fullScreenCover(isPresented: self.$showingFullScreen) {
+                self.fullScreenContent
             }
         }
 
-        struct MessageBubble: View {
-            let file: Occulta.File
-            let mode: Conversation.Modes
-            var attachmentManager: AttachmentManager? = nil
-            var onDelete: (() -> Void)? = nil
+        private var fileSize: String? {
+            guard let url  = self.file.url,
+                  let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize,
+                  size > 0
+            else { return nil }
+            return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+        }
 
-            @State private var showingFullScreen = false
-            @State private var videoPlayer: AVPlayer? = nil
-            @State private var decryptedImage: UIImage? = nil
-            @State private var showingShare = false
-            @Environment(\.colorScheme) private var colorScheme
-
-            var body: some View {
-                HStack(alignment: .center) {
-                    Spacer()
-                    
-                    VStack(alignment: .trailing, spacing: 6) {
-                        self.contentPreview
-                        
-                        if let date = self.file.date {
-                            Text(date, format: .dateTime.hour().minute())
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-                .padding(.horizontal, 16)
-                .fullScreenCover(isPresented: self.$showingFullScreen) {
-                    self.fullScreenContent
-                }
+        @ViewBuilder private var fullScreenContent: some View {
+            if case .file(let meta) = self.file.format,
+               FileExtensions.Image(rawValue: meta.extension ?? "") != nil {
+                FullScreenImageViewer(image: self.decryptedImage)
             }
+        }
 
-            private var fileSize: String? {
-                guard let url = self.file.url,
-                      let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize,
-                      size > 0
-                else { return nil }
-                return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
-            }
-
-            @ViewBuilder
-            private var fullScreenContent: some View {
-                switch self.file.format {
-                case .file(let metadata):
-                    if let _ = FileExtensions.Image(rawValue: metadata.extension ?? "") {
-                        FullScreenImageViewer(image: self.decryptedImage)
-                    }
-                default:
-                    EmptyView()
-                }
-            }
-
-            @ViewBuilder
-            private var contentPreview: some View {
-                switch self.file.format {
-                case .text:
-                    if let data = self.file.content, let text = String(data: data, encoding: .utf8) {
-                        Text(text.withDetectedLinks())
-                            .padding(14)
-                            .background(Color.green.opacity(0.2))
-                            .foregroundStyle(self.colorScheme == .dark ? .white : .black)
-                            .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .contextMenu {
-                                Button {
-                                    UIPasteboard.general.setItems([[UIPasteboard.typeAutomatic: text]], options: [.expirationDate: Date().addingTimeInterval(120)])
-                                    UIPasteboard.general.string = text
-                                    UINotificationFeedbackGenerator().notificationOccurred(.success)
-                                } label: {
-                                    Label("Copy", systemImage: "doc.on.doc")
-                                }
-                                if let onDelete = self.onDelete {
-                                    Button(role: .destructive, action: onDelete) {
-                                        Label("Delete", systemImage: "trash")
-                                    }
-                                }
-                            }
-                    }
-                case .file(let metadata):
-                    let name = metadata.name ?? "file"
-                    
-                    if let _ = FileExtensions.Image(rawValue: metadata.extension ?? "") {
-                        VStack(spacing: 6) {
-                            Group {
-                                if let img = self.decryptedImage {
-                                    Image(uiImage: img).resizable().scaledToFill()
-                                } else {
-                                    ProgressView()
-                                }
-                            }
-                            .frame(maxWidth: 260, maxHeight: 320)
-                            .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .onTapGesture { guard self.decryptedImage != nil else { return }; self.showingFullScreen = true }
-                            .task(id: "\(self.file.url?.path ?? "")|\(self.attachmentManager != nil)") {
-                                guard let manager = self.attachmentManager, let url = self.file.url else { return }
-                                self.decryptedImage = try? await manager.image(at: url)
-                            }
-                            .contextMenu {
-                                if case .read = self.mode {
-                                    Button { self.showingShare = true } label: {
-                                        Label("Share", systemImage: "square.and.arrow.up")
-                                    }
-                                }
-                                if let onDelete = self.onDelete {
-                                    Button(role: .destructive, action: onDelete) {
-                                        Label("Delete", systemImage: "trash")
-                                    }
-                                }
-                            }
-                            .sheet(isPresented: self.$showingShare) {
-                                if let manager = self.attachmentManager, let url = self.file.url {
-                                    let ext  = metadata.extension ?? "jpg"
-                                    let type = UTType(filenameExtension: ext) ?? .image
-                                    ActivityView(activityItems: [manager.shareProvider(at: url, filename: metadata.name ?? "image", contentType: type)])
-                                }
-                            }
-
-                            HStack(spacing: 4) {
-                                Text(name)
-                                    .font(.caption)
-                                    .foregroundStyle(.primary)
-                                if let size = self.fileSize {
-                                    Text("·")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                    Text(size)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                        }
-                    } else if let _ = FileExtensions.Video(rawValue: metadata.extension ?? ""), let url = self.file.url {
-                        VStack(spacing: 6) {
-                            Group {
-                                if let player = self.videoPlayer {
-                                    VideoPlayer(player: player)
-                                } else {
-                                    Color.black
-                                }
-                            }
-                            .frame(width: 260, height: 200)
-                            .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .onAppear {
-                                self.videoPlayer = self.attachmentManager?.player(for: url) ?? AVPlayer(url: url)
-                            }
-                            .onDisappear { self.videoPlayer = nil }
-                            .contextMenu {
-                                if case .read = self.mode {
-                                    Button { self.showingShare = true } label: {
-                                        Label("Share", systemImage: "square.and.arrow.up")
-                                    }
-                                }
-                                if let onDelete = self.onDelete {
-                                    Button(role: .destructive, action: onDelete) {
-                                        Label("Delete", systemImage: "trash")
-                                    }
-                                }
-                            }
-                            .sheet(isPresented: self.$showingShare) {
-                                if let manager = self.attachmentManager {
-                                    let ext  = metadata.extension ?? "mov"
-                                    let type = UTType(filenameExtension: ext) ?? .movie
-                                    ActivityView(activityItems: [manager.shareProvider(at: url, filename: name, contentType: type)])
-                                }
-                            }
-
-                            HStack(spacing: 4) {
-                                Text(name)
-                                    .font(.caption)
-                                    .foregroundStyle(.primary)
-                                if let size = self.fileSize {
-                                    Text("·")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                    Text(size)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                        }
-                    } else {
-                        HStack {
-                            Image(systemName: "doc.fill")
-                                .font(.title2)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(name).lineLimit(1)
-                                if let size = self.fileSize {
-                                    Text(size)
-                                        .font(.caption2)
-                                        .foregroundStyle(.white.opacity(0.7))
-                                }
-                            }
-                        }
+        @ViewBuilder private var contentPreview: some View {
+            switch self.file.format {
+            case .text:
+                if let data = self.file.content, let text = String(data: data, encoding: .utf8) {
+                    Text(text.withDetectedLinks())
                         .padding(14)
-                        .background(Color.blue)
-                        .foregroundStyle(.white)
+                        .background(Color.occultaAccent.opacity(0.15))
+                        .foregroundStyle(self.colorScheme == .dark ? .white : .black)
                         .clipShape(RoundedRectangle(cornerRadius: 18))
                         .contextMenu {
-                            if case .read = self.mode, self.file.url != nil {
-                                Button { self.showingShare = true } label: {
-                                    Label("Share", systemImage: "square.and.arrow.up")
-                                }
+                            Button {
+                                UIPasteboard.general.setItems(
+                                    [[UIPasteboard.typeAutomatic: text]],
+                                    options: [.expirationDate: Date().addingTimeInterval(120)]
+                                )
+                                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                            } label: {
+                                Label("Copy", systemImage: "doc.on.doc")
                             }
                             if let onDelete = self.onDelete {
                                 Button(role: .destructive, action: onDelete) {
@@ -496,357 +293,227 @@ struct ComposableMessage: View {
                                 }
                             }
                         }
-                        .sheet(isPresented: self.$showingShare) {
-                            if let manager = self.attachmentManager, let url = self.file.url {
-                                let ext  = metadata.extension ?? "bin"
-                                let type = UTType(filenameExtension: ext) ?? .data
-                                ActivityView(activityItems: [manager.shareProvider(at: url, filename: name, contentType: type)])
-                            }
-                        }
-                    }
-                default:
-                    Text("Unsupported content")
-                        .padding(14)
-                        .background(Color.blue)
-                        .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 18))
                 }
-            }
-        }
-        
-        struct DateHeader: View {
-            let date: Date
-            
-            var body: some View {
-                Text(self.decideHeader(for: self.date))
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 16)
-                    .background(Color(.systemGray5))
-                    .clipShape(Capsule())
-                    .frame(maxWidth: .infinity)
-            }
-            
-            private func decideHeader(for date: Date) -> String {
-                let calendar = Calendar.current
-                let formatter = DateFormatter()
-                
-                if calendar.isDateInToday(date) { return "Today" }
-                if calendar.isDateInYesterday(date) { return "Yesterday" }
-                
-                formatter.dateStyle = .medium
-                
-                return formatter.string(from: date)
-            }
-        }
-        
-        private func shouldShowDateSeparator(before: Occulta.File, current: Occulta.File) -> Bool {
-            guard
-                let d1 = before.date,
-                let d2 = current.date
-            else {
-                return false
-            }
-            
-            return !Calendar.current.isDate(d1, inSameDayAs: d2)
-        }
-    }
-    
-    private func deleteMessage(_ file: Occulta.File) {
-        if let url = file.url { try? FileManager.default.removeItem(at: url) }
-        self.messages.removeAll { $0.id == file.id }
-    }
 
-    private func addTextMessage() {
-        let trimmed = self.messageText.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        guard !trimmed.isEmpty else { return }
-        
-        let newFile = Occulta.File(content: trimmed.data(using: .utf8), format: .text, date: Date())
-        
-        self.messages.append(newFile)
-        self.messageText = ""
-    }
-    
-    private func handleMedia(_ result: PHPickerResult) async {
-        let provider    = result.itemProvider
-        let typeID      = provider.registeredTypeIdentifiers.first ?? UTType.data.identifier
-        let contentType = UTType(typeID) ?? .data
-        let ext         = contentType.preferredFilenameExtension ?? "bin"
-        let filename    = "media_\(UUID().uuidString.prefix(8))"
-        let url         = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-        let isVideo     = FileExtensions.Video(rawValue: ext) != nil
-
-        #if DEBUG
-        print("[handleMedia] registeredTypeIdentifiers: \(provider.registeredTypeIdentifiers)")
-        print("[handleMedia] typeID=\(typeID) ext=\(ext) isVideo=\(isVideo) assetID=\(result.assetIdentifier ?? "nil")")
-        #endif
-
-        guard let manager = self.attachmentManager else {
-            #if DEBUG
-            print("[handleMedia] no attachmentManager — unencrypted fallback")
-            #endif
-            do {
-                let data = try await loadItemData(from: provider, typeID: typeID)
-                try data.writeProtected(to: url)
-                self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
-            } catch { self.showErrorAlert(error.localizedDescription) }
-            return
-        }
-
-        if isVideo {
-            #if DEBUG
-            print("[handleMedia] → streaming path")
-            #endif
-            let pending = PendingImport(filename: filename, ext: ext)
-            let thumbTypeID = "com.apple.private.photos.thumbnail.standard"
-            
-            self.pendingImports.append(pending)
-            
-            if provider.hasItemConformingToTypeIdentifier(thumbTypeID) {
-                Task { @MainActor in
-                    if let data = try? await loadItemData(from: provider, typeID: thumbTypeID),
-                       let image = UIImage(data: data),
-                       let idx = self.pendingImports.firstIndex(where: { $0.id == pending.id }) {
-                        self.pendingImports[idx].thumbnail = image
-                    }
-                }
-            }
-            do {
-                try await self.streamVideo(provider: provider, typeID: typeID, pendingID: pending.id, ext: ext, filename: filename, url: url, manager: manager)
-            } catch {
-                self.pendingImports.removeAll { $0.id == pending.id }
-                self.showErrorAlert(error.localizedDescription)
-            }
-        } else {
-            #if DEBUG
-            print("[handleMedia] → loadTransferable fallback (isVideo=\(isVideo) assetID=\(result.assetIdentifier ?? "nil"))")
-            #endif
-            do {
-                let data = try await loadItemData(from: provider, typeID: typeID)
-                #if DEBUG
-                print("[handleMedia] loaded \(data.count) bytes via itemProvider")
-                #endif
-                try manager.encrypt(data, to: url)
-                self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
-            } catch { self.showErrorAlert(error.localizedDescription) }
-        }
-    }
-
-    private func streamVideo(
-        provider: NSItemProvider,
-        typeID: String,
-        pendingID: UUID,
-        ext: String,
-        filename: String,
-        url: URL,
-        manager: AttachmentManager
-    ) async throws {
-        if let idx = self.pendingImports.firstIndex(where: { $0.id == pendingID }) {
-            self.pendingImports[idx].isLoading = false
-        }
-
-        let encryptor = try manager.streamingEncryptor(to: url)
-        let pageSize  = Int(getpagesize())
-
-        // NSItemProvider — no Photos authorization needed; picker grant is sufficient.
-        // For large files the delivered Data is mmap-backed: iterating in 64 KB slices and
-        // calling MADV_DONTNEED after each lets the kernel reclaim pages as we go,
-        // keeping resident memory bounded to one slice regardless of file size.
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, providerError in
-                do {
-                    if let err = providerError { throw err }
-                    guard let data else { throw ImportError.noVideoResource }
-                    var encryptError: Error? = nil
-                    data.withUnsafeBytes { rawPtr in
-                        guard let base = rawPtr.baseAddress else { return }
-                        var offset = 0
-                        while offset < data.count, encryptError == nil {
-                            let take = min(65_536, data.count - offset)
-                            autoreleasepool {
-                                do { try encryptor.append(Data(bytes: base.advanced(by: offset), count: take)) }
-                                catch { encryptError = error }
-                            }
-                            let adviseLen = ((take + pageSize - 1) / pageSize) * pageSize
-                            madvise(UnsafeMutableRawPointer(mutating: base.advanced(by: offset)), adviseLen, MADV_DONTNEED)
-                            offset += take
-                        }
-                    }
-                    if let err = encryptError { throw err }
-                    try encryptor.finalize()
-                    cont.resume()
-                } catch {
-                    cont.resume(throwing: error)
-                }
-            }
-        }
-
-        self.pendingImports.removeAll { $0.id == pendingID }
-        self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
-    }
-
-    private func phThumbnail(for asset: PHAsset) async -> UIImage? {
-        await withCheckedContinuation { cont in
-            let opts = PHImageRequestOptions()
-            opts.deliveryMode = .fastFormat
-            opts.isNetworkAccessAllowed = true
-            PHImageManager.default().requestImage(
-                for: asset,
-                targetSize: CGSize(width: 600, height: 600),
-                contentMode: .aspectFit,
-                options: opts
-            ) { image, _ in cont.resume(returning: image) }
-        }
-    }
-
-    private func handleFile(_ result: Result<[URL], Error>) {
-        Task {
-            do {
-                guard
-                    let url = try result.get().first,
-                    url.startAccessingSecurityScopedResource()
-                else { return }
-                defer { url.stopAccessingSecurityScopedResource() }
-
-                let filename = url.deletingPathExtension().lastPathComponent
-                let ext      = url.pathExtension
-                let tmp      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-
-                if let manager = self.attachmentManager {
-                    let source    = try FileHandle(forReadingFrom: url)
-                    let encryptor = try manager.streamingEncryptor(to: tmp)
-                    defer { try? source.close() }
-                    do {
-                        while let chunk = try source.read(upToCount: 65_536), !chunk.isEmpty {
-                            try encryptor.append(chunk)
-                        }
-                        try encryptor.finalize()
-                    } catch {
-                        try? FileManager.default.removeItem(at: tmp)
-                        throw error
-                    }
+            case .file(let metadata):
+                let name = metadata.name ?? "file"
+                if FileExtensions.Image(rawValue: metadata.extension ?? "") != nil {
+                    self.imageBubble(name: name, metadata: metadata)
+                } else if FileExtensions.Video(rawValue: metadata.extension ?? "") != nil,
+                          let url = self.file.url {
+                    self.videoBubble(name: name, url: url, metadata: metadata)
                 } else {
-                    let data = try Data(contentsOf: url, options: .mappedIfSafe)
-                    try data.writeProtected(to: tmp)
+                    self.genericFileBubble(name: name, metadata: metadata)
                 }
 
-                let file = Occulta.File(url: tmp, format: .file(.init(name: filename, extension: ext)), date: Date())
-                await MainActor.run { self.messages.append(file) }
-            } catch {
-                self.showErrorAlert(error.localizedDescription)
+            default:
+                Text("Unsupported content")
+                    .padding(14)
+                    .background(Color.occultaAccent)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 18))
             }
         }
-    }
-    
-    private func encrypt() {
-        Task {
-            do {
-                // Process files to convert the ones that contain only urls to files to files with actual content
-                
-                let processed: [Occulta.File] = try await withThrowingTaskGroup(of: Occulta.File.self) { group in
-                    for file in self.messages {
-                        if let url = file.url {
-                            let manager = self.attachmentManager
-                            
-                            group.addTask {
-                                let data: Data
-                                
-                                if let manager {
-                                    data = try await manager.data(at: url)
-                                } else {
-                                    let (d, _) = try await URLSession.shared.data(from: url)
-                                    data = d
-                                }
-                                return Occulta.File(content: data, format: file.format, date: file.date)
-                            }
-                        } else {
-                            let captured = file
-                            group.addTask { captured }
+
+        @ViewBuilder private func imageBubble(name: String, metadata: Occulta.File.Metadata) -> some View {
+            VStack(spacing: 6) {
+                Group {
+                    if let img = self.decryptedImage {
+                        Image(uiImage: img).resizable().scaledToFill()
+                    } else {
+                        ProgressView().tint(.occultaAccent)
+                    }
+                }
+                .frame(maxWidth: 260, maxHeight: 320)
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .onTapGesture { guard self.decryptedImage != nil else { return }; self.showingFullScreen = true }
+                .task(id: "\(self.file.url?.path ?? "")|\(self.attachmentManager != nil)") {
+                    guard let manager = self.attachmentManager, let url = self.file.url else { return }
+                    self.decryptedImage = try? await manager.image(at: url)
+                }
+                .contextMenu {
+                    if case .read = self.mode {
+                        Button { self.showingShare = true } label: {
+                            Label("Share", systemImage: "square.and.arrow.up")
                         }
                     }
-                    var results: [Occulta.File] = []
-                    for try await file in group { results.append(file) }
-                    
-                    return results.sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
+                    if let onDelete = self.onDelete {
+                        Button(role: .destructive, action: onDelete) {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+                .sheet(isPresented: self.$showingShare) {
+                    if let manager = self.attachmentManager, let url = self.file.url {
+                        let ext  = metadata.extension ?? "jpg"
+                        let type = UTType(filenameExtension: ext) ?? .image
+                        ActivityView(activityItems: [manager.shareProvider(at: url, filename: name, contentType: type)])
+                    }
                 }
 
-                // Encode & Encrypt
-
-                let basket = Basket(files: processed)
-
-                let contactPub = try? self.contactManager?.currentPublicKey(forIdentifier: self.identifier)
-                let shardOps   = try self.shardCustodyManager?.buildShardOperations(for: self.identifier, currentContactPublicKey: contactPub) ?? []
-                let manifest_  = try? self.shardCustodyManager?.buildCustodyManifest(for: self.identifier)
-                let expected: [UUID]?
-                if let custody = self.shardCustodyManager, let vm = self.vaultManager {
-                    expected = try? custody.buildExpectedShards(for: self.identifier, vaultManager: vm)
-                } else {
-                    expected = nil
-                }
-
-                let encryptedData: Data?
-                do {
-                    encryptedData = try self.contactManager?.encryptBundle(
-                        basket:          basket,
-                        for:             self.identifier,
-                        shardOperations: shardOps.isEmpty ? nil : shardOps,
-                        custodyManifest: manifest_,
-                        expectedShards:  expected
-                    )
-                } catch ContactManager.Errors.trusteeLacksQuantumMaterial {
-                    // Quantum material corrupted or missing — fall back to classical,
-                    // strip shard ops (they stay pending and will retry after re-exchange).
-                    encryptedData = try self.contactManager?.encryptBundle(
-                        basket: basket,
-                        for:    self.identifier
-                    )
-                } catch {
-                    debugPrint("Error: \(error)")
-                    encryptedData = nil
-                }
-                
-                guard
-                    let encrypted = encryptedData, encrypted.isEmpty == false
-                else {
-                    self.showErrorAlert("There is nothing to encrypt, try again.")
-                    
-                    return
-                }
-                
-                let id = UUID().uuidString.components(separatedBy: "-").last ?? "encrypted.file"
-                let tempURL = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("\(id).occ")
-                
-                try encrypted.writeProtected(to: tempURL)
-                
-                await MainActor.run {
-                    self.encryptedResultURL = tempURL
-                }
-            } catch {
-                self.showErrorAlert(error.localizedDescription)
+                self.fileCaptionRow(name: name)
             }
         }
-    }
-    
-    @MainActor
-    private func showErrorAlert(_ message: String) {
-        self.errorMessage = message
-        self.showError = true
+
+        @ViewBuilder private func videoBubble(name: String, url: URL, metadata: Occulta.File.Metadata) -> some View {
+            VStack(spacing: 6) {
+                Group {
+                    if let player = self.videoPlayer { VideoPlayer(player: player) }
+                    else { Color.black }
+                }
+                .frame(width: 260, height: 200)
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .onAppear { self.videoPlayer = self.attachmentManager?.player(for: url) ?? AVPlayer(url: url) }
+                .onDisappear { self.videoPlayer = nil }
+                .contextMenu {
+                    if case .read = self.mode {
+                        Button { self.showingShare = true } label: {
+                            Label("Share", systemImage: "square.and.arrow.up")
+                        }
+                    }
+                    if let onDelete = self.onDelete {
+                        Button(role: .destructive, action: onDelete) {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+                .sheet(isPresented: self.$showingShare) {
+                    if let manager = self.attachmentManager {
+                        let ext  = metadata.extension ?? "mov"
+                        let type = UTType(filenameExtension: ext) ?? .movie
+                        ActivityView(activityItems: [manager.shareProvider(at: url, filename: name, contentType: type)])
+                    }
+                }
+
+                self.fileCaptionRow(name: name)
+            }
+        }
+
+        @ViewBuilder private func genericFileBubble(name: String, metadata: Occulta.File.Metadata) -> some View {
+            HStack {
+                Image(systemName: "doc.fill").font(.title2)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(name).lineLimit(1)
+                    if let size = self.fileSize {
+                        Text(size).font(.caption2).foregroundStyle(.white.opacity(0.7))
+                    }
+                }
+            }
+            .padding(14)
+            .background(Color.occultaAccent)
+            .foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+            .contextMenu {
+                if case .read = self.mode, self.file.url != nil {
+                    Button { self.showingShare = true } label: {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                }
+                if let onDelete = self.onDelete {
+                    Button(role: .destructive, action: onDelete) {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
+            }
+            .sheet(isPresented: self.$showingShare) {
+                if let manager = self.attachmentManager, let url = self.file.url {
+                    let ext  = metadata.extension ?? "bin"
+                    let type = UTType(filenameExtension: ext) ?? .data
+                    ActivityView(activityItems: [manager.shareProvider(at: url, filename: name, contentType: type)])
+                }
+            }
+        }
+
+        @ViewBuilder private func fileCaptionRow(name: String) -> some View {
+            HStack(spacing: 4) {
+                Text(name).font(.caption).foregroundStyle(.primary)
+                if let size = self.fileSize {
+                    Text("·").font(.caption).foregroundStyle(.secondary)
+                    Text(size).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
     }
 }
 
-// MARK: - Full-screen viewers
+// MARK: - DateHeader
+
+extension ComposableMessage {
+    struct DateHeader: View {
+        let date: Date
+
+        var body: some View {
+            Text(self.label)
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 16)
+                .background(Color(.systemGray5))
+                .clipShape(Capsule())
+                .frame(maxWidth: .infinity)
+        }
+
+        private var label: String {
+            let cal = Calendar.current
+            if cal.isDateInToday(date)     { return "Today" }
+            if cal.isDateInYesterday(date) { return "Yesterday" }
+            let f = DateFormatter(); f.dateStyle = .medium
+            return f.string(from: date)
+        }
+    }
+}
+
+// MARK: - PendingImportBubble
+
+private struct PendingImportBubble: View {
+    let pending: PendingImport
+
+    var body: some View {
+        HStack(alignment: .center) {
+            Spacer()
+            VStack(alignment: .trailing, spacing: 6) {
+                ZStack {
+                    if let thumb = self.pending.thumbnail {
+                        Image(uiImage: thumb).resizable().scaledToFill()
+                        Color.black.opacity(0.4)
+                    } else {
+                        Color.black
+                    }
+                    VStack(spacing: 6) {
+                        ProgressView().tint(.white)
+                        Text("Loading…").font(.caption2).foregroundStyle(.white)
+                    }
+                }
+                .frame(width: 260, height: 200)
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+
+                ProgressView(value: self.pending.progress)
+                    .tint(.occultaAccent)
+                    .frame(width: 260)
+                    .animation(.linear(duration: 0.1), value: self.pending.progress)
+
+                HStack(spacing: 4) {
+                    Text(self.pending.filename).font(.caption).foregroundStyle(.primary)
+                    Text("·").font(.caption).foregroundStyle(.secondary)
+                    Text(self.pending.isLoading ? "Loading…" : "Encrypting…")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - FullScreenImageViewer
 
 private struct FullScreenImageViewer: View {
     let image: UIImage?
     @Environment(\.dismiss) private var dismiss
 
-    @State private var scale: CGFloat = 1.0
-    @State private var offset: CGSize = .zero
-    @GestureState private var gestureScale: CGFloat = 1.0
-    @GestureState private var gestureOffset: CGSize = .zero
+    @State private var scale:         CGFloat  = 1.0
+    @State private var offset:        CGSize   = .zero
+    @GestureState private var gestureScale:  CGFloat  = 1.0
+    @GestureState private var gestureOffset: CGSize   = .zero
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -858,7 +525,7 @@ private struct FullScreenImageViewer: View {
                     .scaledToFit()
                     .scaleEffect(max(1, self.scale * self.gestureScale))
                     .offset(
-                        x: self.offset.width + self.gestureOffset.width,
+                        x: self.offset.width  + self.gestureOffset.width,
                         y: self.offset.height + self.gestureOffset.height
                     )
                     .gesture(
@@ -883,10 +550,7 @@ private struct FullScreenImageViewer: View {
                             }
                     )
                     .onTapGesture(count: 2) {
-                        withAnimation(.spring()) {
-                            self.scale  = 1
-                            self.offset = .zero
-                        }
+                        withAnimation(.spring()) { self.scale = 1; self.offset = .zero }
                     }
             } else {
                 ProgressView().tint(.white)
@@ -901,30 +565,6 @@ private struct FullScreenImageViewer: View {
             }
             .padding()
         }
-    }
-}
-
-// MARK: -
-
-enum ImportError: LocalizedError {
-    case assetNotFound
-    case noVideoResource
-
-    var errorDescription: String? {
-        switch self {
-        case .assetNotFound:      return "Could not find the selected video."
-        case .noVideoResource:    return "The selected item has no video resource."
-        }
-    }
-}
-
-struct FileExtensions {
-    enum Video: String {
-        case mov, mp4, m4v
-    }
-    
-    enum Image: String {
-        case jpg, jpeg, png, heic
     }
 }
 
@@ -944,7 +584,6 @@ struct PHPickerRepresentable: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
-
     func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
 
     final class Coordinator: NSObject, PHPickerViewControllerDelegate {
@@ -958,37 +597,23 @@ struct PHPickerRepresentable: UIViewControllerRepresentable {
     }
 }
 
-private func loadItemData(from provider: NSItemProvider, typeID: String) async throws -> Data {
-    try await withCheckedThrowingContinuation { cont in
-        provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, error in
-            if let data { cont.resume(returning: data) }
-            else { cont.resume(throwing: error ?? ImportError.assetNotFound) }
-        }
-    }
-}
-
 // MARK: - Preview
 
 #Preview {
-    struct Preview: View {
-        @State var messages: [Occulta.File] = []
-        @State var text = ""
-        var body: some View {
-            NavigationStack {
-                ComposableMessage(
-                    identifier: UUID().uuidString,
-                    messages: self.$messages,
-                    messageText: self.$text
-                )
-                .environment(ContactManager.preview)
-            }
-        }
+    NavigationStack {
+        ComposableMessage(vm: ComposeViewModel(identifier: UUID().uuidString))
+            .environment(ContactManager.preview)
     }
-    return Preview()
 }
 
 #Preview {
     NavigationStack {
-        ComposableMessage.Conversation(mode: .read(messageOwner: UUID().uuidString), messages: .constant([File(content: "https://www.apple.com".data(using: .utf8), format: .text), File(content: "Hi".data(using: .utf8), format: .text)]))
+        ComposableMessage.Conversation(
+            mode: .read(messageOwner: UUID().uuidString),
+            messages: .constant([
+                Occulta.File(content: "https://www.apple.com".data(using: .utf8), format: .text),
+                Occulta.File(content: "Hi".data(using: .utf8), format: .text)
+            ])
+        )
     }
 }

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -54,7 +54,7 @@ struct ComposableMessage: View {
                         .multilineTextAlignment(.center)
                 }
             } else {
-                Conversation(mode: .write, messages: self.$messages)
+                Conversation(mode: .write, messages: self.$messages, onDelete: self.deleteMessage)
             }
             
             HStack(alignment: .center, spacing: 10) {
@@ -140,6 +140,7 @@ struct ComposableMessage: View {
     struct Conversation: View {
         let mode: Modes
         @Binding var messages: [Occulta.File]
+        var onDelete: ((Occulta.File) -> Void)? = nil
 
         enum Modes {
             case read(messageOwner: String), write
@@ -165,8 +166,8 @@ struct ComposableMessage: View {
                                     if index == 0 || self.shouldShowDateSeparator(before: self.messages[index - 1], current: file) {
                                         DateHeader(date: file.date ?? Date())
                                     }
-                                    
-                                    MessageBubble(file: file, mode: self.mode)
+
+                                    MessageBubble(file: file, mode: self.mode, onDelete: self.onDelete.map { cb in { cb(file) } })
                                 }
                                 .id(file.id)
                             }
@@ -217,6 +218,7 @@ struct ComposableMessage: View {
         struct MessageBubble: View {
             let file: Occulta.File
             let mode: Conversation.Modes
+            var onDelete: (() -> Void)? = nil
 
             @State private var showingFullScreen = false
             @Environment(\.colorScheme) private var colorScheme
@@ -279,6 +281,11 @@ struct ComposableMessage: View {
                                 } label: {
                                     Label("Copy", systemImage: "doc.on.doc")
                                 }
+                                if let onDelete = self.onDelete {
+                                    Button(role: .destructive, action: onDelete) {
+                                        Label("Delete", systemImage: "trash")
+                                    }
+                                }
                             }
                     }
                 case .file(let metadata):
@@ -304,6 +311,11 @@ struct ComposableMessage: View {
                             .contextMenu {
                                 if case .read = self.mode, let url = self.file.url {
                                     ShareLink(item: url) { Label("Share", systemImage: "square.and.arrow.up") }
+                                }
+                                if let onDelete = self.onDelete {
+                                    Button(role: .destructive, action: onDelete) {
+                                        Label("Delete", systemImage: "trash")
+                                    }
                                 }
                             }
 
@@ -336,6 +348,11 @@ struct ComposableMessage: View {
                                 if case .read = self.mode {
                                     ShareLink(item: url) {
                                         Label("Share", systemImage: "square.and.arrow.up")
+                                    }
+                                }
+                                if let onDelete = self.onDelete {
+                                    Button(role: .destructive, action: onDelete) {
+                                        Label("Delete", systemImage: "trash")
                                     }
                                 }
                             }
@@ -375,6 +392,11 @@ struct ComposableMessage: View {
                             if case .read = self.mode, let url = self.file.url {
                                 ShareLink(item: url) {
                                     Label("Share", systemImage: "square.and.arrow.up")
+                                }
+                            }
+                            if let onDelete = self.onDelete {
+                                Button(role: .destructive, action: onDelete) {
+                                    Label("Delete", systemImage: "trash")
                                 }
                             }
                         }
@@ -428,6 +450,11 @@ struct ComposableMessage: View {
         }
     }
     
+    private func deleteMessage(_ file: Occulta.File) {
+        if let url = file.url { try? FileManager.default.removeItem(at: url) }
+        self.messages.removeAll { $0.id == file.id }
+    }
+
     private func addTextMessage() {
         let trimmed = self.messageText.trimmingCharacters(in: .whitespacesAndNewlines)
         

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -14,6 +14,7 @@ struct PendingImport: Identifiable {
     let ext:      String
     var thumbnail: UIImage? = nil
     var progress:  Double   = 0
+    var isLoading: Bool     = true
 }
 
 struct ComposableMessage: View {
@@ -260,9 +261,11 @@ struct ComposableMessage: View {
                             }
                             VStack(spacing: 6) {
                                 ProgressView().tint(.white)
-                                Text(self.pending.progress > 0
-                                     ? "\(Int(self.pending.progress * 100))%"
-                                     : "Encrypting…")
+                                Text(self.pending.isLoading
+                                     ? "Loading…"
+                                     : self.pending.progress > 0
+                                       ? "\(Int(self.pending.progress * 100))%"
+                                       : "Encrypting…")
                                     .font(.caption2)
                                     .foregroundStyle(.white)
                             }
@@ -282,7 +285,7 @@ struct ComposableMessage: View {
                             Text("·")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
-                            Text("Encrypting…")
+                            Text(self.pending.isLoading ? "Loading…" : "Encrypting…")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -571,24 +574,38 @@ struct ComposableMessage: View {
     }
     
     private func handleMedia(_ item: PhotosPickerItem) async {
-        do {
-            guard let data = try await item.loadTransferable(type: Data.self) else { return }
+        let contentType = item.supportedContentTypes.first ?? .data
+        let ext      = contentType.preferredFilenameExtension ?? "bin"
+        let filename = "media_\(UUID().uuidString.prefix(8))"
+        let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
+        let isVideo  = FileExtensions.Video(rawValue: ext) != nil
 
-            let contentType = item.supportedContentTypes.first ?? .data
-            let ext      = contentType.preferredFilenameExtension ?? "bin"
-            let filename = "media_\(UUID().uuidString.prefix(8))"
-            let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-
-            guard let manager = self.attachmentManager else {
+        guard let manager = self.attachmentManager else {
+            do {
+                guard let data = try await item.loadTransferable(type: Data.self) else { return }
                 try data.writeProtected(to: url)
                 self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
+            } catch { self.showErrorAlert(error.localizedDescription) }
+            return
+        }
+
+        var pendingID: UUID? = nil
+        if isVideo {
+            let pending = PendingImport(filename: filename, ext: ext)
+            pendingID = pending.id
+            self.pendingImports.append(pending)
+        }
+
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self) else {
+                if let id = pendingID { self.pendingImports.removeAll { $0.id == id } }
                 return
             }
 
-            if FileExtensions.Video(rawValue: ext) != nil {
-                let pending = PendingImport(filename: filename, ext: ext)
-                self.pendingImports.append(pending)
-                let id = pending.id
+            if isVideo, let id = pendingID {
+                if let idx = self.pendingImports.firstIndex(where: { $0.id == id }) {
+                    self.pendingImports[idx].isLoading = false
+                }
 
                 Task {
                     if let thumb = await AttachmentManager.videoThumbnail(from: data, fileExtension: ext),
@@ -611,6 +628,7 @@ struct ComposableMessage: View {
 
             self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
         } catch {
+            if let id = pendingID { self.pendingImports.removeAll { $0.id == id } }
             self.showErrorAlert(error.localizedDescription)
         }
     }

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -521,8 +521,13 @@ struct ComposableMessage: View {
                     }
                 }
                 
+                // Staging files have been read into `processed` — delete them now
+                for file in self.messages {
+                    if let url = file.url { try? FileManager.default.removeItem(at: url) }
+                }
+
                 // Encode & Encrypt
-                
+
                 let basket = Basket(files: processed)
 
                 let contactPub = try? self.contactManager?.currentPublicKey(forIdentifier: self.identifier)

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -221,6 +221,7 @@ struct ComposableMessage: View {
             var onDelete: (() -> Void)? = nil
 
             @State private var showingFullScreen = false
+            @State private var videoThumbnail: UIImage? = nil
             @Environment(\.colorScheme) private var colorScheme
 
             var body: some View {
@@ -247,6 +248,15 @@ struct ComposableMessage: View {
                       size > 0
                 else { return nil }
                 return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+            }
+
+            private func loadVideoThumbnail(from url: URL) async {
+                let asset = AVURLAsset(url: url)
+                let generator = AVAssetImageGenerator(asset: asset)
+                generator.appliesPreferredTrackTransform = true
+                generator.maximumSize = CGSize(width: 520, height: 400)
+                guard let cgImage = try? await generator.image(at: .zero).image else { return }
+                await MainActor.run { self.videoThumbnail = UIImage(cgImage: cgImage) }
             }
 
             @ViewBuilder
@@ -336,14 +346,22 @@ struct ComposableMessage: View {
                     } else if let _ = FileExtensions.Video(rawValue: metadata.extension ?? ""), let url = self.file.url {
                         VStack(spacing: 6) {
                             ZStack {
-                                Color.black
+                                if let thumbnail = self.videoThumbnail {
+                                    Image(uiImage: thumbnail)
+                                        .resizable()
+                                        .scaledToFill()
+                                } else {
+                                    Color.black
+                                }
                                 Image(systemName: "play.circle.fill")
                                     .font(.system(size: 44))
                                     .foregroundStyle(.white)
+                                    .shadow(radius: 4)
                             }
                             .frame(width: 260, height: 200)
                             .clipShape(RoundedRectangle(cornerRadius: 18))
                             .onTapGesture { self.showingFullScreen = true }
+                            .task { await self.loadVideoThumbnail(from: url) }
                             .contextMenu {
                                 if case .read = self.mode {
                                     ShareLink(item: url) {

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -135,9 +135,6 @@ struct ComposableMessage: View {
         } message: {
             Text(self.errorMessage)
         }
-        .onDisappear {
-            FileManager.default.clearTemporaryDirectory()
-        }
     }
     
     struct Conversation: View {

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -333,7 +333,7 @@ struct ComposableMessage: View {
                 switch self.file.format {
                 case .file(let metadata):
                     if let _ = FileExtensions.Image(rawValue: metadata.extension ?? "") {
-                        FullScreenImageViewer(url: self.file.url)
+                        FullScreenImageViewer(image: self.decryptedImage)
                     }
                 default:
                     EmptyView()
@@ -379,7 +379,7 @@ struct ComposableMessage: View {
                             }
                             .frame(maxWidth: 260, maxHeight: 320)
                             .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .onTapGesture { self.showingFullScreen = true }
+                            .onTapGesture { guard self.decryptedImage != nil else { return }; self.showingFullScreen = true }
                             .task(id: self.file.url) {
                                 guard let manager = self.attachmentManager, let url = self.file.url else { return }
                                 self.decryptedImage = try? await manager.image(at: url)
@@ -840,7 +840,7 @@ struct ComposableMessage: View {
 // MARK: - Full-screen viewers
 
 private struct FullScreenImageViewer: View {
-    let url: URL?
+    let image: UIImage?
     @Environment(\.dismiss) private var dismiss
 
     @State private var scale: CGFloat = 1.0
@@ -852,47 +852,44 @@ private struct FullScreenImageViewer: View {
         ZStack(alignment: .topTrailing) {
             Color.black.ignoresSafeArea()
 
-            AsyncImage(url: self.url) { phase in
-                switch phase {
-                case .success(let image):
-                    image
-                        .resizable()
-                        .scaledToFit()
-                        .scaleEffect(max(1, self.scale * self.gestureScale))
-                        .offset(
-                            x: self.offset.width + self.gestureOffset.width,
-                            y: self.offset.height + self.gestureOffset.height
-                        )
-                        .gesture(
-                            MagnificationGesture()
-                                .updating(self.$gestureScale) { value, state, _ in state = value }
-                                .onEnded { value in
-                                    let newScale = max(1, self.scale * value)
-                                    self.scale = newScale
-                                    if newScale == 1 { self.offset = .zero }
-                                }
-                        )
-                        .simultaneousGesture(
-                            DragGesture()
-                                .updating(self.$gestureOffset) { value, state, _ in
-                                    guard self.scale > 1 else { return }
-                                    state = value.translation
-                                }
-                                .onEnded { value in
-                                    guard self.scale > 1 else { return }
-                                    self.offset.width  += value.translation.width
-                                    self.offset.height += value.translation.height
-                                }
-                        )
-                        .onTapGesture(count: 2) {
-                            withAnimation(.spring()) {
-                                self.scale  = 1
-                                self.offset = .zero
+            if let image = self.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .scaleEffect(max(1, self.scale * self.gestureScale))
+                    .offset(
+                        x: self.offset.width + self.gestureOffset.width,
+                        y: self.offset.height + self.gestureOffset.height
+                    )
+                    .gesture(
+                        MagnificationGesture()
+                            .updating(self.$gestureScale) { value, state, _ in state = value }
+                            .onEnded { value in
+                                let newScale = max(1, self.scale * value)
+                                self.scale = newScale
+                                if newScale == 1 { self.offset = .zero }
                             }
+                    )
+                    .simultaneousGesture(
+                        DragGesture()
+                            .updating(self.$gestureOffset) { value, state, _ in
+                                guard self.scale > 1 else { return }
+                                state = value.translation
+                            }
+                            .onEnded { value in
+                                guard self.scale > 1 else { return }
+                                self.offset.width  += value.translation.width
+                                self.offset.height += value.translation.height
+                            }
+                    )
+                    .onTapGesture(count: 2) {
+                        withAnimation(.spring()) {
+                            self.scale  = 1
+                            self.offset = .zero
                         }
-                default:
-                    ProgressView().tint(.white)
-                }
+                    }
+            } else {
+                ProgressView().tint(.white)
             }
 
             Button { self.dismiss() } label: {

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -51,6 +51,7 @@ struct ComposableMessage: View {
                     messages: self.$vm.messages,
                     pendingImports: self.vm.pendingImports,
                     attachmentManager: self.vm.attachmentManager,
+                    thumbnails: self.vm.thumbnails,
                     onDelete: { self.vm.deleteMessage($0) }
                 )
             }
@@ -154,12 +155,38 @@ extension ComposableMessage {
     struct Conversation: View {
         let mode: Modes
         @Binding var messages: [Occulta.File]
-        var pendingImports:    [PendingImport]       = []
-        var attachmentManager: AttachmentManager?    = nil
+        var pendingImports:    [PendingImport]    = []
+        var attachmentManager: AttachmentManager? = nil
+        var thumbnails:        [URL: UIImage]     = [:]
         var onDelete:          ((Occulta.File) -> Void)? = nil
 
         enum Modes {
             case read(messageOwner: String), write
+        }
+
+        private enum Item: Identifiable {
+            case message(Occulta.File, showHeader: Bool)
+            case pending(PendingImport, showHeader: Bool)
+
+            var id: UUID {
+                switch self {
+                case .message(let f, _): return f.id
+                case .pending(let p, _): return p.id
+                }
+            }
+        }
+
+        private var items: [Item] {
+            var result: [Item] = []
+            for (i, file) in self.messages.enumerated() {
+                let show = i == 0 || self.shouldShowDateSeparator(before: self.messages[i - 1], current: file)
+                result.append(.message(file, showHeader: show))
+            }
+            let hasToday = self.messages.last?.date.map { Calendar.current.isDateInToday($0) } ?? false
+            for (i, pending) in self.pendingImports.enumerated() {
+                result.append(.pending(pending, showHeader: !hasToday && i == 0))
+            }
+            return result
         }
 
         var body: some View {
@@ -171,25 +198,8 @@ extension ComposableMessage {
                 ScrollViewReader { proxy in
                     ScrollView {
                         LazyVStack(alignment: .trailing, spacing: 24) {
-                            ForEach(Array(self.messages.enumerated()), id: \.element.id) { index, file in
-                                VStack(spacing: 6) {
-                                    if index == 0 || self.shouldShowDateSeparator(
-                                        before: self.messages[index - 1], current: file
-                                    ) {
-                                        DateHeader(date: file.date ?? Date())
-                                    }
-                                    MessageBubble(
-                                        file: file,
-                                        mode: self.mode,
-                                        attachmentManager: self.attachmentManager,
-                                        onDelete: self.onDelete.map { cb in { cb(file) } }
-                                    )
-                                }
-                                .id(file.id)
-                            }
-                            ForEach(self.pendingImports) { pending in
-                                PendingImportBubble(pending: pending)
-                                    .id("pending-\(pending.id.uuidString)")
+                            ForEach(self.items) { item in
+                                self.itemView(item).id(item.id)
                             }
                         }
                         .padding(.horizontal, 16)
@@ -205,10 +215,31 @@ extension ComposableMessage {
                     .onChange(of: self.pendingImports.count) { _, _ in
                         withAnimation(.easeOut(duration: 0.3)) {
                             if let last = self.pendingImports.last {
-                                proxy.scrollTo("pending-\(last.id.uuidString)", anchor: .bottom)
+                                proxy.scrollTo(last.id, anchor: .bottom)
                             }
                         }
                     }
+                }
+            }
+        }
+
+        @ViewBuilder private func itemView(_ item: Item) -> some View {
+            switch item {
+            case .message(let file, let showHeader):
+                VStack(spacing: 6) {
+                    if showHeader { DateHeader(date: file.date ?? Date()) }
+                    MessageBubble(
+                        file: file,
+                        mode: self.mode,
+                        attachmentManager: self.attachmentManager,
+                        thumbnails: self.thumbnails,
+                        onDelete: self.onDelete.map { cb in { cb(file) } }
+                    )
+                }
+            case .pending(let pending, let showHeader):
+                VStack(spacing: 6) {
+                    if showHeader { DateHeader(date: Date()) }
+                    PendingImportBubble(pending: pending)
                 }
             }
         }
@@ -227,10 +258,12 @@ extension ComposableMessage {
         let file:              Occulta.File
         let mode:              Conversation.Modes
         var attachmentManager: AttachmentManager? = nil
+        var thumbnails:        [URL: UIImage]      = [:]
         var onDelete:          (() -> Void)?      = nil
 
         @State private var showingFullScreen = false
         @State private var videoPlayer:    AVPlayer? = nil
+        @State private var isPlaying:      Bool      = false
         @State private var decryptedImage: UIImage?  = nil
         @State private var showingShare = false
         @Environment(\.colorScheme) private var colorScheme
@@ -247,7 +280,6 @@ extension ComposableMessage {
                     }
                 }
             }
-            .padding(.horizontal, 16)
             .fullScreenCover(isPresented: self.$showingFullScreen) {
                 self.fullScreenContent
             }
@@ -357,23 +389,34 @@ extension ComposableMessage {
 
         @ViewBuilder private func videoBubble(name: String, url: URL, metadata: Occulta.File.Metadata) -> some View {
             VStack(spacing: 6) {
-                ZStack {
+                Group {
                     if let player = self.videoPlayer {
-                        VideoPlayer(player: player)
+                        VideoPlayerView(player: player)
                     } else {
-                        Color.black
-                        Image(systemName: "play.circle.fill")
-                            .font(.system(size: 44))
-                            .foregroundStyle(.white.opacity(0.85))
+                        if let thumb = self.thumbnails[url] {
+                            Image(uiImage: thumb).resizable().scaledToFill()
+                        } else {
+                            Color.black
+                        }
                     }
                 }
                 .frame(width: 260, height: 200)
                 .clipShape(RoundedRectangle(cornerRadius: 18))
                 .onTapGesture {
-                    guard self.videoPlayer == nil else { return }
-                    self.videoPlayer = self.attachmentManager?.player(for: url) ?? AVPlayer(url: url)
+                    if let player = self.videoPlayer {
+                        if self.isPlaying { player.pause() } else { player.play() }
+                        
+                        self.isPlaying.toggle()
+                    } else {
+                        let player = self.attachmentManager?.player(for: url) ?? AVPlayer(url: url)
+                        self.videoPlayer = player
+                        
+                        player.play()
+                        
+                        self.isPlaying = true
+                    }
                 }
-                .onDisappear { self.videoPlayer = nil }
+                .onDisappear { self.videoPlayer = nil; self.isPlaying = false }
                 .contextMenu {
                     if case .read = self.mode {
                         Button { self.showingShare = true } label: {
@@ -390,6 +433,7 @@ extension ComposableMessage {
                     if let manager = self.attachmentManager {
                         let ext  = metadata.extension ?? "mov"
                         let type = UTType(filenameExtension: ext) ?? .movie
+                        
                         ActivityView(activityItems: [manager.shareProvider(at: url, filename: name, contentType: type)])
                     }
                 }
@@ -436,9 +480,13 @@ extension ComposableMessage {
         @ViewBuilder private func fileCaptionRow(name: String) -> some View {
             HStack(spacing: 4) {
                 Text(name).font(.caption).foregroundStyle(.primary)
+                
                 if let size = self.fileSize {
                     Text("·").font(.caption).foregroundStyle(.secondary)
                     Text(size).font(.caption).foregroundStyle(.secondary)
+                } else {
+                    Text("")
+                    Text("")
                 }
             }
         }
@@ -481,35 +529,29 @@ private struct PendingImportBubble: View {
         HStack(alignment: .center) {
             Spacer()
             VStack(alignment: .trailing, spacing: 6) {
-                ZStack {
-                    if let thumb = self.pending.thumbnail {
-                        Image(uiImage: thumb).resizable().scaledToFill()
-                        Color.black.opacity(0.4)
-                    } else {
+                VStack(spacing: 6) {
+                    ZStack {
                         Color.black
+                        VStack(spacing: 6) {
+                            ProgressView().tint(.white)
+                            Text("Loading…").font(.caption2).foregroundStyle(.white)
+                        }
                     }
-                    VStack(spacing: 6) {
-                        ProgressView().tint(.white)
-                        Text("Loading…").font(.caption2).foregroundStyle(.white)
+                    .frame(width: 260, height: 200)
+                    .clipShape(RoundedRectangle(cornerRadius: 18))
+
+                    HStack(spacing: 4) {
+                        Text(self.pending.filename).font(.caption).foregroundStyle(.primary)
+                        Text("·").font(.caption).foregroundStyle(.secondary)
+                        Text(self.pending.isLoading ? "Loading…" : "Encrypting…")
+                            .font(.caption).foregroundStyle(.secondary)
                     }
                 }
-                .frame(width: 260, height: 200)
-                .clipShape(RoundedRectangle(cornerRadius: 18))
-
-                ProgressView(value: self.pending.progress)
-                    .tint(.occultaAccent)
-                    .frame(width: 260)
-                    .animation(.linear(duration: 0.1), value: self.pending.progress)
-
-                HStack(spacing: 4) {
-                    Text(self.pending.filename).font(.caption).foregroundStyle(.primary)
-                    Text("·").font(.caption).foregroundStyle(.secondary)
-                    Text(self.pending.isLoading ? "Loading…" : "Encrypting…")
-                        .font(.caption).foregroundStyle(.secondary)
-                }
+                Text(Date(), format: .dateTime.hour().minute())
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
         }
-        .padding(.horizontal, 16)
     }
 }
 
@@ -525,7 +567,7 @@ private struct FullScreenImageViewer: View {
     @GestureState private var gestureOffset: CGSize   = .zero
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        ZStack {
             Color.black.ignoresSafeArea()
 
             if let image = self.image {
@@ -564,7 +606,8 @@ private struct FullScreenImageViewer: View {
             } else {
                 ProgressView().tint(.white)
             }
-
+        }
+        .overlay(alignment: .topTrailing) {
             Button { self.dismiss() } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 16, weight: .semibold))
@@ -574,6 +617,28 @@ private struct FullScreenImageViewer: View {
             }
             .padding()
         }
+    }
+}
+
+// MARK: - VideoPlayerView
+
+private struct VideoPlayerView: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> PlayerUIView {
+        let view = PlayerUIView()
+        view.playerLayer.player = self.player
+        view.playerLayer.videoGravity = .resizeAspectFill
+        return view
+    }
+
+    func updateUIView(_ view: PlayerUIView, context: Context) {
+        view.playerLayer.player = self.player
+    }
+
+    final class PlayerUIView: UIView {
+        override class var layerClass: AnyClass { AVPlayerLayer.self }
+        var playerLayer: AVPlayerLayer { self.layer as! AVPlayerLayer }
     }
 }
 

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -303,8 +303,10 @@ struct ComposableMessage: View {
             var body: some View {
                 HStack(alignment: .center) {
                     Spacer()
+                    
                     VStack(alignment: .trailing, spacing: 6) {
                         self.contentPreview
+                        
                         if let date = self.file.date {
                             Text(date, format: .dateTime.hour().minute())
                                 .font(.caption2)
@@ -365,6 +367,7 @@ struct ComposableMessage: View {
                     }
                 case .file(let metadata):
                     let name = metadata.name ?? "file"
+                    
                     if let _ = FileExtensions.Image(rawValue: metadata.extension ?? "") {
                         VStack(spacing: 6) {
                             Group {
@@ -742,15 +745,31 @@ struct ComposableMessage: View {
             do {
                 // Process files to convert the ones that contain only urls to files to files with actual content
                 
-                var processed: [Occulta.File] = []
-                
-                for file in self.messages {
-                    if let url = file.url {
-                        let (data, _) = try await URLSession.shared.data(from: url)
-                        processed.append(Occulta.File(content: data, format: file.format, date: file.date))
-                    } else {
-                        processed.append(file)
+                let processed: [Occulta.File] = try await withThrowingTaskGroup(of: Occulta.File.self) { group in
+                    for file in self.messages {
+                        if let url = file.url {
+                            let manager = self.attachmentManager
+                            
+                            group.addTask {
+                                let data: Data
+                                
+                                if let manager {
+                                    data = try await manager.data(at: url)
+                                } else {
+                                    let (d, _) = try await URLSession.shared.data(from: url)
+                                    data = d
+                                }
+                                return Occulta.File(content: data, format: file.format, date: file.date)
+                            }
+                        } else {
+                            let captured = file
+                            group.addTask { captured }
+                        }
                     }
+                    var results: [Occulta.File] = []
+                    for try await file in group { results.append(file) }
+                    
+                    return results.sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
                 }
 
                 // Encode & Encrypt

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -28,6 +28,7 @@ struct ComposableMessage: View {
     @State private var encryptedResultURL: URL?
     @State private var showError = false
     @State private var errorMessage = ""
+    @State private var attachmentManager: AttachmentManager? = nil
 
     init(
         identifier: String,
@@ -54,7 +55,7 @@ struct ComposableMessage: View {
                         .multilineTextAlignment(.center)
                 }
             } else {
-                Conversation(mode: .write, messages: self.$messages, onDelete: self.deleteMessage)
+                Conversation(mode: .write, messages: self.$messages, attachmentManager: self.attachmentManager, onDelete: self.deleteMessage)
             }
             
             HStack(alignment: .center, spacing: 10) {
@@ -135,11 +136,16 @@ struct ComposableMessage: View {
         } message: {
             Text(self.errorMessage)
         }
+        .task {
+            guard let key = try? self.contactManager?.fileEncryptionKey(for: self.identifier) else { return }
+            self.attachmentManager = AttachmentManager(contactKey: key)
+        }
     }
     
     struct Conversation: View {
         let mode: Modes
         @Binding var messages: [Occulta.File]
+        var attachmentManager: AttachmentManager? = nil
         var onDelete: ((Occulta.File) -> Void)? = nil
 
         enum Modes {
@@ -167,7 +173,7 @@ struct ComposableMessage: View {
                                         DateHeader(date: file.date ?? Date())
                                     }
 
-                                    MessageBubble(file: file, mode: self.mode, onDelete: self.onDelete.map { cb in { cb(file) } })
+                                    MessageBubble(file: file, mode: self.mode, attachmentManager: self.attachmentManager, onDelete: self.onDelete.map { cb in { cb(file) } })
                                 }
                                 .id(file.id)
                             }
@@ -218,10 +224,13 @@ struct ComposableMessage: View {
         struct MessageBubble: View {
             let file: Occulta.File
             let mode: Conversation.Modes
+            var attachmentManager: AttachmentManager? = nil
             var onDelete: (() -> Void)? = nil
 
             @State private var showingFullScreen = false
             @State private var videoPlayer: AVPlayer? = nil
+            @State private var decryptedImage: UIImage? = nil
+            @State private var showingShare = false
             @Environment(\.colorScheme) private var colorScheme
 
             var body: some View {
@@ -291,30 +300,37 @@ struct ComposableMessage: View {
                     let name = metadata.name ?? "file"
                     if let _ = FileExtensions.Image(rawValue: metadata.extension ?? "") {
                         VStack(spacing: 6) {
-                            AsyncImage(url: self.file.url) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image.resizable().scaledToFill()
-                                case .failure(let error):
-                                    VStack(spacing: 4) {
-                                        Image(systemName: "exclamationmark.triangle").foregroundStyle(.secondary)
-                                        Text(error.localizedDescription).font(.caption2).foregroundStyle(.secondary).multilineTextAlignment(.center)
-                                    }
-                                case .empty: ProgressView()
-                                @unknown default: ProgressView()
+                            Group {
+                                if let img = self.decryptedImage {
+                                    Image(uiImage: img).resizable().scaledToFill()
+                                } else {
+                                    ProgressView()
                                 }
                             }
                             .frame(maxWidth: 260, maxHeight: 320)
                             .clipShape(RoundedRectangle(cornerRadius: 18))
                             .onTapGesture { self.showingFullScreen = true }
+                            .task(id: self.file.url) {
+                                guard let manager = self.attachmentManager, let url = self.file.url else { return }
+                                self.decryptedImage = try? await manager.image(at: url)
+                            }
                             .contextMenu {
-                                if case .read = self.mode, let url = self.file.url {
-                                    ShareLink(item: url) { Label("Share", systemImage: "square.and.arrow.up") }
+                                if case .read = self.mode {
+                                    Button { self.showingShare = true } label: {
+                                        Label("Share", systemImage: "square.and.arrow.up")
+                                    }
                                 }
                                 if let onDelete = self.onDelete {
                                     Button(role: .destructive, action: onDelete) {
                                         Label("Delete", systemImage: "trash")
                                     }
+                                }
+                            }
+                            .sheet(isPresented: self.$showingShare) {
+                                if let manager = self.attachmentManager, let url = self.file.url {
+                                    let ext  = metadata.extension ?? "jpg"
+                                    let type = UTType(filenameExtension: ext) ?? .image
+                                    ActivityView(activityItems: [manager.shareProvider(at: url, filename: metadata.name ?? "image", contentType: type)])
                                 }
                             }
 
@@ -343,11 +359,13 @@ struct ComposableMessage: View {
                             }
                             .frame(width: 260, height: 200)
                             .clipShape(RoundedRectangle(cornerRadius: 18))
-                            .onAppear { self.videoPlayer = AVPlayer(url: url) }
+                            .onAppear {
+                                self.videoPlayer = self.attachmentManager?.player(for: url) ?? AVPlayer(url: url)
+                            }
                             .onDisappear { self.videoPlayer = nil }
                             .contextMenu {
                                 if case .read = self.mode {
-                                    ShareLink(item: url) {
+                                    Button { self.showingShare = true } label: {
                                         Label("Share", systemImage: "square.and.arrow.up")
                                     }
                                 }
@@ -355,6 +373,13 @@ struct ComposableMessage: View {
                                     Button(role: .destructive, action: onDelete) {
                                         Label("Delete", systemImage: "trash")
                                     }
+                                }
+                            }
+                            .sheet(isPresented: self.$showingShare) {
+                                if let manager = self.attachmentManager {
+                                    let ext  = metadata.extension ?? "mov"
+                                    let type = UTType(filenameExtension: ext) ?? .movie
+                                    ActivityView(activityItems: [manager.shareProvider(at: url, filename: name, contentType: type)])
                                 }
                             }
 
@@ -390,8 +415,8 @@ struct ComposableMessage: View {
                         .foregroundStyle(.white)
                         .clipShape(RoundedRectangle(cornerRadius: 18))
                         .contextMenu {
-                            if case .read = self.mode, let url = self.file.url {
-                                ShareLink(item: url) {
+                            if case .read = self.mode, self.file.url != nil {
+                                Button { self.showingShare = true } label: {
                                     Label("Share", systemImage: "square.and.arrow.up")
                                 }
                             }
@@ -399,6 +424,13 @@ struct ComposableMessage: View {
                                 Button(role: .destructive, action: onDelete) {
                                     Label("Delete", systemImage: "trash")
                                 }
+                            }
+                        }
+                        .sheet(isPresented: self.$showingShare) {
+                            if let manager = self.attachmentManager, let url = self.file.url {
+                                let ext  = metadata.extension ?? "bin"
+                                let type = UTType(filenameExtension: ext) ?? .data
+                                ActivityView(activityItems: [manager.shareProvider(at: url, filename: name, contentType: type)])
                             }
                         }
                     }
@@ -474,7 +506,11 @@ struct ComposableMessage: View {
             let ext      = contentType.preferredFilenameExtension ?? "bin"
             let filename = "media_\(UUID().uuidString.prefix(8))"
             let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-            try data.writeProtected(to: url)
+            if let manager = self.attachmentManager {
+                try manager.encrypt(data, to: url)
+            } else {
+                try data.writeProtected(to: url)
+            }
             let file = Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date())
             await MainActor.run { self.messages.append(file) }
         } catch {
@@ -494,7 +530,11 @@ struct ComposableMessage: View {
                 let filename = url.deletingPathExtension().lastPathComponent
                 let ext      = url.pathExtension
                 let tmp      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-                try data.writeProtected(to: tmp)
+                if let manager = self.attachmentManager {
+                    try manager.encrypt(data, to: tmp)
+                } else {
+                    try data.writeProtected(to: tmp)
+                }
                 let file = Occulta.File(url: tmp, format: .file(.init(name: filename, extension: ext)), date: Date())
                 await MainActor.run { self.messages.append(file) }
             } catch {

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -357,13 +357,22 @@ extension ComposableMessage {
 
         @ViewBuilder private func videoBubble(name: String, url: URL, metadata: Occulta.File.Metadata) -> some View {
             VStack(spacing: 6) {
-                Group {
-                    if let player = self.videoPlayer { VideoPlayer(player: player) }
-                    else { Color.black }
+                ZStack {
+                    if let player = self.videoPlayer {
+                        VideoPlayer(player: player)
+                    } else {
+                        Color.black
+                        Image(systemName: "play.circle.fill")
+                            .font(.system(size: 44))
+                            .foregroundStyle(.white.opacity(0.85))
+                    }
                 }
                 .frame(width: 260, height: 200)
                 .clipShape(RoundedRectangle(cornerRadius: 18))
-                .onAppear { self.videoPlayer = self.attachmentManager?.player(for: url) ?? AVPlayer(url: url) }
+                .onTapGesture {
+                    guard self.videoPlayer == nil else { return }
+                    self.videoPlayer = self.attachmentManager?.player(for: url) ?? AVPlayer(url: url)
+                }
                 .onDisappear { self.videoPlayer = nil }
                 .contextMenu {
                     if case .read = self.mode {

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -8,6 +8,14 @@ extension URL: @retroactive Identifiable {
     public var id: String { absoluteString }
 }
 
+struct PendingImport: Identifiable {
+    let id       = UUID()
+    let filename: String
+    let ext:      String
+    var thumbnail: UIImage? = nil
+    var progress:  Double   = 0
+}
+
 struct ComposableMessage: View {
     @Environment(ContactManager.self) private var contactManager: ContactManager?
     @Environment(ShardCustodyManager.self) private var shardCustodyManager: ShardCustodyManager?
@@ -29,6 +37,7 @@ struct ComposableMessage: View {
     @State private var showError = false
     @State private var errorMessage = ""
     @State private var attachmentManager: AttachmentManager? = nil
+    @State private var pendingImports: [PendingImport] = []
 
     init(
         identifier: String,
@@ -47,7 +56,7 @@ struct ComposableMessage: View {
     
     var body: some View {
         VStack {
-            if self.messages.isEmpty {
+            if self.messages.isEmpty && self.pendingImports.isEmpty {
                 ContentUnavailableView {
                     Label("Add content", systemImage: "plus.circle")
                 } description: {
@@ -55,7 +64,7 @@ struct ComposableMessage: View {
                         .multilineTextAlignment(.center)
                 }
             } else {
-                Conversation(mode: .write, messages: self.$messages, attachmentManager: self.attachmentManager, onDelete: self.deleteMessage)
+                Conversation(mode: .write, messages: self.$messages, pendingImports: self.pendingImports, attachmentManager: self.attachmentManager, onDelete: self.deleteMessage)
             }
             
             HStack(alignment: .center, spacing: 10) {
@@ -145,6 +154,7 @@ struct ComposableMessage: View {
     struct Conversation: View {
         let mode: Modes
         @Binding var messages: [Occulta.File]
+        var pendingImports: [PendingImport] = []
         var attachmentManager: AttachmentManager? = nil
         var onDelete: ((Occulta.File) -> Void)? = nil
 
@@ -177,6 +187,10 @@ struct ComposableMessage: View {
                                 }
                                 .id(file.id)
                             }
+                            ForEach(self.pendingImports) { pending in
+                                PendingImportBubble(pending: pending)
+                                    .id("pending-\(pending.id.uuidString)")
+                            }
                         }
                         .padding(.horizontal, 16)
                         .padding(.bottom, 20)
@@ -187,6 +201,13 @@ struct ComposableMessage: View {
                         withAnimation(.easeOut(duration: 0.3)) {
                             if let last = latest.last {
                                 proxy.scrollTo(last.id, anchor: .bottom)
+                            }
+                        }
+                    }
+                    .onChange(of: self.pendingImports.count) { _, _ in
+                        withAnimation(.easeOut(duration: 0.3)) {
+                            if let last = self.pendingImports.last {
+                                proxy.scrollTo("pending-\(last.id.uuidString)", anchor: .bottom)
                             }
                         }
                     }
@@ -221,6 +242,56 @@ struct ComposableMessage: View {
             }
         }
         
+        private struct PendingImportBubble: View {
+            let pending: PendingImport
+
+            var body: some View {
+                HStack(alignment: .center) {
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 6) {
+                        ZStack {
+                            if let thumb = self.pending.thumbnail {
+                                Image(uiImage: thumb)
+                                    .resizable()
+                                    .scaledToFill()
+                                Color.black.opacity(0.4)
+                            } else {
+                                Color.black
+                            }
+                            VStack(spacing: 6) {
+                                ProgressView().tint(.white)
+                                Text(self.pending.progress > 0
+                                     ? "\(Int(self.pending.progress * 100))%"
+                                     : "Encrypting…")
+                                    .font(.caption2)
+                                    .foregroundStyle(.white)
+                            }
+                        }
+                        .frame(width: 260, height: 200)
+                        .clipShape(RoundedRectangle(cornerRadius: 18))
+
+                        ProgressView(value: self.pending.progress)
+                            .tint(.blue)
+                            .frame(width: 260)
+                            .animation(.linear(duration: 0.1), value: self.pending.progress)
+
+                        HStack(spacing: 4) {
+                            Text(self.pending.filename)
+                                .font(.caption)
+                                .foregroundStyle(.primary)
+                            Text("·")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text("Encrypting…")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+
         struct MessageBubble: View {
             let file: Occulta.File
             let mode: Conversation.Modes
@@ -502,17 +573,43 @@ struct ComposableMessage: View {
     private func handleMedia(_ item: PhotosPickerItem) async {
         do {
             guard let data = try await item.loadTransferable(type: Data.self) else { return }
+
             let contentType = item.supportedContentTypes.first ?? .data
             let ext      = contentType.preferredFilenameExtension ?? "bin"
             let filename = "media_\(UUID().uuidString.prefix(8))"
             let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-            if let manager = self.attachmentManager {
-                try manager.encrypt(data, to: url)
-            } else {
+
+            guard let manager = self.attachmentManager else {
                 try data.writeProtected(to: url)
+                self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
+                return
             }
-            let file = Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date())
-            await MainActor.run { self.messages.append(file) }
+
+            if FileExtensions.Video(rawValue: ext) != nil {
+                let pending = PendingImport(filename: filename, ext: ext)
+                self.pendingImports.append(pending)
+                let id = pending.id
+
+                Task {
+                    if let thumb = await AttachmentManager.videoThumbnail(from: data, fileExtension: ext),
+                       let idx = self.pendingImports.firstIndex(where: { $0.id == id }) {
+                        self.pendingImports[idx].thumbnail = thumb
+                    }
+                }
+
+                for try await p in manager.encryptWithProgress(data, to: url) {
+                    if let idx = self.pendingImports.firstIndex(where: { $0.id == id }) {
+                        self.pendingImports[idx].progress = p
+                    }
+                    await Task.yield()
+                }
+
+                self.pendingImports.removeAll { $0.id == id }
+            } else {
+                try manager.encrypt(data, to: url)
+            }
+
+            self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
         } catch {
             self.showErrorAlert(error.localizedDescription)
         }

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SwiftData
 import UniformTypeIdentifiers
 import PhotosUI
+import Photos
 import AVKit
 
 extension URL: @retroactive Identifiable {
@@ -29,7 +30,6 @@ struct ComposableMessage: View {
 
     @Binding var messages: [Occulta.File]
     @Binding var messageText: String
-    @Binding var selectedMediaItems: [PhotosPickerItem]
 
     // Local UI state
     @State private var showMediaPicker = false
@@ -43,13 +43,11 @@ struct ComposableMessage: View {
     init(
         identifier: String,
         messages: Binding<[Occulta.File]>,
-        messageText: Binding<String>,
-        selectedMediaItems: Binding<[PhotosPickerItem]>
+        messageText: Binding<String>
     ) {
         self.identifier = identifier
         self._messages = messages
         self._messageText = messageText
-        self._selectedMediaItems = selectedMediaItems
 
         let predicate = #Predicate<Contact.Profile> { $0.identifier == identifier }
         self._contacts = Query(filter: predicate)
@@ -125,17 +123,15 @@ struct ComposableMessage: View {
                                 if let stagingURL = file.url { try? FileManager.default.removeItem(at: stagingURL) }
                             }
                             self.messages = []
-                            self.selectedMediaItems = []
                         }
                     })
                 }
             }
         }
         .background(Color(.systemGroupedBackground))
-        .photosPicker(isPresented: self.$showMediaPicker, selection: self.$selectedMediaItems, matching: .any(of: [.images, .videos]))
-        .onChange(of: self.selectedMediaItems) { _, newValue in
-            newValue.forEach { item in
-                Task { await self.handleMedia(item) }
+        .sheet(isPresented: self.$showMediaPicker) {
+            PHPickerRepresentable(isPresented: self.$showMediaPicker) { results in
+                results.forEach { result in Task { await self.handleMedia(result) } }
             }
         }
         .fileImporter(isPresented: self.$showFileImporter, allowedContentTypes: [.data], allowsMultipleSelection: false) { result in
@@ -261,11 +257,8 @@ struct ComposableMessage: View {
                             }
                             VStack(spacing: 6) {
                                 ProgressView().tint(.white)
-                                Text(self.pending.isLoading
-                                     ? "Loading…"
-                                     : self.pending.progress > 0
-                                       ? "\(Int(self.pending.progress * 100))%"
-                                       : "Encrypting…")
+                                
+                                Text("Loading…")
                                     .font(.caption2)
                                     .foregroundStyle(.white)
                             }
@@ -333,7 +326,7 @@ struct ComposableMessage: View {
                 return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
             }
 
-@ViewBuilder
+            @ViewBuilder
             private var fullScreenContent: some View {
                 switch self.file.format {
                 case .file(let metadata):
@@ -573,63 +566,135 @@ struct ComposableMessage: View {
         self.messageText = ""
     }
     
-    private func handleMedia(_ item: PhotosPickerItem) async {
-        let contentType = item.supportedContentTypes.first ?? .data
-        let ext      = contentType.preferredFilenameExtension ?? "bin"
-        let filename = "media_\(UUID().uuidString.prefix(8))"
-        let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-        let isVideo  = FileExtensions.Video(rawValue: ext) != nil
+    private func handleMedia(_ result: PHPickerResult) async {
+        let provider    = result.itemProvider
+        let typeID      = provider.registeredTypeIdentifiers.first ?? UTType.data.identifier
+        let contentType = UTType(typeID) ?? .data
+        let ext         = contentType.preferredFilenameExtension ?? "bin"
+        let filename    = "media_\(UUID().uuidString.prefix(8))"
+        let url         = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
+        let isVideo     = FileExtensions.Video(rawValue: ext) != nil
+
+        #if DEBUG
+        print("[handleMedia] registeredTypeIdentifiers: \(provider.registeredTypeIdentifiers)")
+        print("[handleMedia] typeID=\(typeID) ext=\(ext) isVideo=\(isVideo) assetID=\(result.assetIdentifier ?? "nil")")
+        #endif
 
         guard let manager = self.attachmentManager else {
+            #if DEBUG
+            print("[handleMedia] no attachmentManager — unencrypted fallback")
+            #endif
             do {
-                guard let data = try await item.loadTransferable(type: Data.self) else { return }
+                let data = try await loadItemData(from: provider, typeID: typeID)
                 try data.writeProtected(to: url)
                 self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
             } catch { self.showErrorAlert(error.localizedDescription) }
             return
         }
 
-        var pendingID: UUID? = nil
         if isVideo {
+            #if DEBUG
+            print("[handleMedia] → streaming path")
+            #endif
             let pending = PendingImport(filename: filename, ext: ext)
-            pendingID = pending.id
+            let thumbTypeID = "com.apple.private.photos.thumbnail.standard"
+            
             self.pendingImports.append(pending)
+            
+            if provider.hasItemConformingToTypeIdentifier(thumbTypeID) {
+                Task { @MainActor in
+                    if let data = try? await loadItemData(from: provider, typeID: thumbTypeID),
+                       let image = UIImage(data: data),
+                       let idx = self.pendingImports.firstIndex(where: { $0.id == pending.id }) {
+                        self.pendingImports[idx].thumbnail = image
+                    }
+                }
+            }
+            do {
+                try await self.streamVideo(provider: provider, typeID: typeID, pendingID: pending.id, ext: ext, filename: filename, url: url, manager: manager)
+            } catch {
+                self.pendingImports.removeAll { $0.id == pending.id }
+                self.showErrorAlert(error.localizedDescription)
+            }
+        } else {
+            #if DEBUG
+            print("[handleMedia] → loadTransferable fallback (isVideo=\(isVideo) assetID=\(result.assetIdentifier ?? "nil"))")
+            #endif
+            do {
+                let data = try await loadItemData(from: provider, typeID: typeID)
+                #if DEBUG
+                print("[handleMedia] loaded \(data.count) bytes via itemProvider")
+                #endif
+                try manager.encrypt(data, to: url)
+                self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
+            } catch { self.showErrorAlert(error.localizedDescription) }
+        }
+    }
+
+    private func streamVideo(
+        provider: NSItemProvider,
+        typeID: String,
+        pendingID: UUID,
+        ext: String,
+        filename: String,
+        url: URL,
+        manager: AttachmentManager
+    ) async throws {
+        if let idx = self.pendingImports.firstIndex(where: { $0.id == pendingID }) {
+            self.pendingImports[idx].isLoading = false
         }
 
-        do {
-            guard let data = try await item.loadTransferable(type: Data.self) else {
-                if let id = pendingID { self.pendingImports.removeAll { $0.id == id } }
-                return
-            }
+        let encryptor = try manager.streamingEncryptor(to: url)
+        let pageSize  = Int(getpagesize())
 
-            if isVideo, let id = pendingID {
-                if let idx = self.pendingImports.firstIndex(where: { $0.id == id }) {
-                    self.pendingImports[idx].isLoading = false
-                }
-
-                Task {
-                    if let thumb = await AttachmentManager.videoThumbnail(from: data, fileExtension: ext),
-                       let idx = self.pendingImports.firstIndex(where: { $0.id == id }) {
-                        self.pendingImports[idx].thumbnail = thumb
+        // NSItemProvider — no Photos authorization needed; picker grant is sufficient.
+        // For large files the delivered Data is mmap-backed: iterating in 64 KB slices and
+        // calling MADV_DONTNEED after each lets the kernel reclaim pages as we go,
+        // keeping resident memory bounded to one slice regardless of file size.
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, providerError in
+                do {
+                    if let err = providerError { throw err }
+                    guard let data else { throw ImportError.noVideoResource }
+                    var encryptError: Error? = nil
+                    data.withUnsafeBytes { rawPtr in
+                        guard let base = rawPtr.baseAddress else { return }
+                        var offset = 0
+                        while offset < data.count, encryptError == nil {
+                            let take = min(65_536, data.count - offset)
+                            autoreleasepool {
+                                do { try encryptor.append(Data(bytes: base.advanced(by: offset), count: take)) }
+                                catch { encryptError = error }
+                            }
+                            let adviseLen = ((take + pageSize - 1) / pageSize) * pageSize
+                            madvise(UnsafeMutableRawPointer(mutating: base.advanced(by: offset)), adviseLen, MADV_DONTNEED)
+                            offset += take
+                        }
                     }
+                    if let err = encryptError { throw err }
+                    try encryptor.finalize()
+                    cont.resume()
+                } catch {
+                    cont.resume(throwing: error)
                 }
-
-                for try await p in manager.encryptWithProgress(data, to: url) {
-                    if let idx = self.pendingImports.firstIndex(where: { $0.id == id }) {
-                        self.pendingImports[idx].progress = p
-                    }
-                    await Task.yield()
-                }
-
-                self.pendingImports.removeAll { $0.id == id }
-            } else {
-                try manager.encrypt(data, to: url)
             }
+        }
 
-            self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
-        } catch {
-            if let id = pendingID { self.pendingImports.removeAll { $0.id == id } }
-            self.showErrorAlert(error.localizedDescription)
+        self.pendingImports.removeAll { $0.id == pendingID }
+        self.messages.append(Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date()))
+    }
+
+    private func phThumbnail(for asset: PHAsset) async -> UIImage? {
+        await withCheckedContinuation { cont in
+            let opts = PHImageRequestOptions()
+            opts.deliveryMode = .fastFormat
+            opts.isNetworkAccessAllowed = true
+            PHImageManager.default().requestImage(
+                for: asset,
+                targetSize: CGSize(width: 600, height: 600),
+                contentMode: .aspectFit,
+                options: opts
+            ) { image, _ in cont.resume(returning: image) }
         }
     }
 
@@ -641,15 +706,29 @@ struct ComposableMessage: View {
                     url.startAccessingSecurityScopedResource()
                 else { return }
                 defer { url.stopAccessingSecurityScopedResource() }
-                let data     = try await URLSession.shared.data(from: url).0
+
                 let filename = url.deletingPathExtension().lastPathComponent
                 let ext      = url.pathExtension
                 let tmp      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
+
                 if let manager = self.attachmentManager {
-                    try manager.encrypt(data, to: tmp)
+                    let source    = try FileHandle(forReadingFrom: url)
+                    let encryptor = try manager.streamingEncryptor(to: tmp)
+                    defer { try? source.close() }
+                    do {
+                        while let chunk = try source.read(upToCount: 65_536), !chunk.isEmpty {
+                            try encryptor.append(chunk)
+                        }
+                        try encryptor.finalize()
+                    } catch {
+                        try? FileManager.default.removeItem(at: tmp)
+                        throw error
+                    }
                 } else {
+                    let data = try Data(contentsOf: url, options: .mappedIfSafe)
                     try data.writeProtected(to: tmp)
                 }
+
                 let file = Occulta.File(url: tmp, format: .file(.init(name: filename, extension: ext)), date: Date())
                 await MainActor.run { self.messages.append(file) }
             } catch {
@@ -811,6 +890,18 @@ private struct FullScreenImageViewer: View {
 
 // MARK: -
 
+enum ImportError: LocalizedError {
+    case assetNotFound
+    case noVideoResource
+
+    var errorDescription: String? {
+        switch self {
+        case .assetNotFound:      return "Could not find the selected video."
+        case .noVideoResource:    return "The selected item has no video resource."
+        }
+    }
+}
+
 struct FileExtensions {
     enum Video: String {
         case mov, mp4, m4v
@@ -821,20 +912,57 @@ struct FileExtensions {
     }
 }
 
+// MARK: - PHPickerRepresentable
+
+struct PHPickerRepresentable: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let onPick: ([PHPickerResult]) -> Void
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config            = PHPickerConfiguration(photoLibrary: .shared())
+        config.filter         = .any(of: [.images, .videos])
+        config.selectionLimit = 0
+        let picker            = PHPickerViewController(configuration: config)
+        picker.delegate       = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    final class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        var parent: PHPickerRepresentable
+        init(parent: PHPickerRepresentable) { self.parent = parent }
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            self.parent.isPresented = false
+            self.parent.onPick(results)
+        }
+    }
+}
+
+private func loadItemData(from provider: NSItemProvider, typeID: String) async throws -> Data {
+    try await withCheckedThrowingContinuation { cont in
+        provider.loadDataRepresentation(forTypeIdentifier: typeID) { data, error in
+            if let data { cont.resume(returning: data) }
+            else { cont.resume(throwing: error ?? ImportError.assetNotFound) }
+        }
+    }
+}
+
 // MARK: - Preview
 
 #Preview {
     struct Preview: View {
         @State var messages: [Occulta.File] = []
         @State var text = ""
-        @State var selected: [PhotosPickerItem] = []
         var body: some View {
             NavigationStack {
                 ComposableMessage(
                     identifier: UUID().uuidString,
                     messages: self.$messages,
-                    messageText: self.$text,
-                    selectedMediaItems: self.$selected
+                    messageText: self.$text
                 )
                 .environment(ContactManager.preview)
             }

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -446,7 +446,7 @@ struct ComposableMessage: View {
             let ext      = contentType.preferredFilenameExtension ?? "bin"
             let filename = "media_\(UUID().uuidString.prefix(8))"
             let url      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-            try data.write(to: url, options: .completeFileProtection)
+            try data.writeProtected(to: url)
             let file = Occulta.File(url: url, format: .file(.init(name: filename, extension: ext)), date: Date())
             await MainActor.run { self.messages.append(file) }
         } catch {
@@ -466,7 +466,7 @@ struct ComposableMessage: View {
                 let filename = url.deletingPathExtension().lastPathComponent
                 let ext      = url.pathExtension
                 let tmp      = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).\(ext)")
-                try data.write(to: tmp, options: .completeFileProtection)
+                try data.writeProtected(to: tmp)
                 let file = Occulta.File(url: tmp, format: .file(.init(name: filename, extension: ext)), date: Date())
                 await MainActor.run { self.messages.append(file) }
             } catch {
@@ -538,7 +538,7 @@ struct ComposableMessage: View {
                 let tempURL = FileManager.default.temporaryDirectory
                     .appendingPathComponent("\(id).occ")
                 
-                try encrypted.write(to: tempURL, options: .completeFileProtection)
+                try encrypted.writeProtected(to: tempURL)
                 
                 await MainActor.run {
                     self.encryptedResultURL = tempURL

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -380,7 +380,7 @@ struct ComposableMessage: View {
                             .frame(maxWidth: 260, maxHeight: 320)
                             .clipShape(RoundedRectangle(cornerRadius: 18))
                             .onTapGesture { guard self.decryptedImage != nil else { return }; self.showingFullScreen = true }
-                            .task(id: self.file.url) {
+                            .task(id: "\(self.file.url?.path ?? "")|\(self.attachmentManager != nil)") {
                                 guard let manager = self.attachmentManager, let url = self.file.url else { return }
                                 self.decryptedImage = try? await manager.image(at: url)
                             }

--- a/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/ComposableMessage.swift
@@ -105,9 +105,15 @@ struct ComposableMessage: View {
                         .clipShape(RoundedRectangle(cornerRadius: 16))
                 }
                 .padding()
-                .sheet(item: self.$encryptedResultURL, content: { url in
-                    ActivityView(activityItems: [url])
-                })
+                .sheet(item: self.$encryptedResultURL) { url in
+                    ActivityView(activityItems: [url], onComplete: { completed in
+                        try? FileManager.default.removeItem(at: url)
+                        if completed {
+                            self.messages = []
+                            self.selectedMediaItems = []
+                        }
+                    })
+                }
             }
         }
         .background(Color(.systemGroupedBackground))

--- a/Occulta/UI/Tabs/Contacts/v1/Contact+Detail.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/Contact+Detail.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import PhotosUI
 
 extension Contact {
     struct Info: View {
@@ -102,15 +103,23 @@ extension Contact {
         }
         
         @State private var editing: Bool = false
-        @State private var displayingVerificationInfo : Bool = false
-        
+        @State private var displayingVerificationInfo: Bool = false
+        @State private var composeMessages: [Occulta.File] = []
+        @State private var composeMessageText = ""
+        @State private var composeSelectedMedia: [PhotosPickerItem] = []
+
         var body: some View {
             VStack {
                 VStack(spacing: 20) {
                     if self.needsExchange {
                         KeyExchange(identifier: self.identifier)
                     } else {
-                        ComposableMessage(identifier: self.identifier)
+                        ComposableMessage(
+                            identifier: self.identifier,
+                            messages: self.$composeMessages,
+                            messageText: self.$composeMessageText,
+                            selectedMediaItems: self.$composeSelectedMedia
+                        )
                     }
                 }
                 .toolbar {

--- a/Occulta/UI/Tabs/Contacts/v1/Contact+Detail.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/Contact+Detail.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import SwiftData
-import PhotosUI
 
 extension Contact {
     struct Info: View {
@@ -106,7 +105,6 @@ extension Contact {
         @State private var displayingVerificationInfo: Bool = false
         @State private var composeMessages: [Occulta.File] = []
         @State private var composeMessageText = ""
-        @State private var composeSelectedMedia: [PhotosPickerItem] = []
 
         var body: some View {
             VStack {
@@ -117,8 +115,7 @@ extension Contact {
                         ComposableMessage(
                             identifier: self.identifier,
                             messages: self.$composeMessages,
-                            messageText: self.$composeMessageText,
-                            selectedMediaItems: self.$composeSelectedMedia
+                            messageText: self.$composeMessageText
                         )
                     }
                 }

--- a/Occulta/UI/Tabs/Contacts/v1/Contact+Detail.swift
+++ b/Occulta/UI/Tabs/Contacts/v1/Contact+Detail.swift
@@ -91,20 +91,16 @@ extension Contact {
             return ourIdentityHash == decryptedOwnerHash
         }
         
-        init(identifier: String) {
-            self.identifier = identifier
-            
-            let predicate = #Predicate<Contact.Profile> {
-                $0.identifier == identifier
-            }
-            
-            self._contacts = Query(filter: predicate)
-        }
-        
         @State private var editing: Bool = false
         @State private var displayingVerificationInfo: Bool = false
-        @State private var composeMessages: [Occulta.File] = []
-        @State private var composeMessageText = ""
+        @State private var composeVM: ComposeViewModel
+
+        init(identifier: String) {
+            self.identifier = identifier
+            let predicate = #Predicate<Contact.Profile> { $0.identifier == identifier }
+            self._contacts = Query(filter: predicate)
+            self._composeVM = State(initialValue: ComposeViewModel(identifier: identifier))
+        }
 
         var body: some View {
             VStack {
@@ -112,11 +108,7 @@ extension Contact {
                     if self.needsExchange {
                         KeyExchange(identifier: self.identifier)
                     } else {
-                        ComposableMessage(
-                            identifier: self.identifier,
-                            messages: self.$composeMessages,
-                            messageText: self.$composeMessageText
-                        )
+                        ComposableMessage(vm: self.composeVM)
                     }
                 }
                 .toolbar {

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -227,15 +227,6 @@ class ShareViewController: UIViewController {
                     )
                 }
 
-                // CRITICAL: copyItem preserves the SOURCE file's protection class, not the
-                // destination directory's. The source is the extension's tmp/ directory, which
-                // uses .completeUntilFirstUserAuthentication or weaker. Without this explicit
-                // call, plaintext files are readable when the device is locked.
-                try (destURL as NSURL).setResourceValue(
-                    URLFileProtection.complete,
-                    forKey: .fileProtectionKey
-                )
-
                 fileEntries.append(ShareManifest.FileEntry(
                     filename: filename, uti: uti, fileExtension: fileExt
                 ))
@@ -280,8 +271,12 @@ class ShareViewController: UIViewController {
         }
     }
 
-    /// Copy via `loadFileRepresentation` — bytes flow through the kernel, not app memory.
+    /// Copy via `loadFileRepresentation`, encrypt with the share key, write ciphertext.
     /// Returns false if this provider doesn't support file representation for the given UTI.
+    ///
+    /// Note: reading the source into Data for encryption reintroduces memory pressure for
+    /// large files. This is an accepted tradeoff — the alternative (streaming AES-GCM) would
+    /// require custom framing not available in CryptoKit.
     private func copyFileRepresentation(
         from provider: NSItemProvider, uti: String, to destination: URL
     ) async throws -> Bool {
@@ -300,8 +295,11 @@ class ShareViewController: UIViewController {
                     return
                 }
                 do {
-                    // sourceURL is valid only inside this closure — copy immediately.
-                    try FileManager.default.copyItem(at: sourceURL, to: destination)
+                    var plaintext = try Data(contentsOf: sourceURL)
+                    let ciphertext = try self.shareKeyManager.encrypt(data: plaintext)
+                    _ = plaintext.withUnsafeMutableBytes { memset($0.baseAddress!, 0, $0.count) }
+                    plaintext = Data()
+                    try ciphertext.write(to: destination, options: .completeFileProtection)
                     continuation.resume(returning: true)
                 } catch {
                     continuation.resume(throwing: error)
@@ -310,12 +308,11 @@ class ShareViewController: UIViewController {
         }
     }
 
-    /// Fallback: load into memory with a 10 MB size guard.
-    /// Uses `.completeFileProtection` in the write options.
+    /// Fallback: load into memory with a 10 MB size guard, encrypt before writing.
     private func copyDataRepresentation(
         from provider: NSItemProvider, uti: String, to destination: URL
     ) async throws {
-        let data: Data = try await withCheckedThrowingContinuation { continuation in
+        var data: Data = try await withCheckedThrowingContinuation { continuation in
             provider.loadDataRepresentation(forTypeIdentifier: uti) { data, error in
                 if let error {
                     continuation.resume(throwing: error)
@@ -333,7 +330,10 @@ class ShareViewController: UIViewController {
             throw ShareError.fileTooLarge
         }
 
-        try data.write(to: destination, options: .completeFileProtection)
+        let ciphertext = try self.shareKeyManager.encrypt(data: data)
+        _ = data.withUnsafeMutableBytes { memset($0.baseAddress!, 0, $0.count) }
+        data = Data()
+        try ciphertext.write(to: destination, options: .completeFileProtection)
     }
 
     // MARK: - Phase 3: Handoff

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -462,21 +462,16 @@ class ShareViewController: UIViewController {
             : (provider.registeredTypeIdentifiers.first ?? UTType.data.identifier)
 
         do {
-            // Prefer file representation — bytes flow through the kernel,
-            // not app memory. Falls back to data representation for
-            // providers that don't support it.
-            let copied = try await self.copyFileRepresentation(
-                from: provider, uti: uti, to: destURL
-            )
-            if !copied {
-                try await self.copyDataRepresentation(
-                    from: provider, uti: uti, to: destURL
-                )
+            // The .occ is already encrypted by the sender — just land it on disk
+            // with NSFileProtection.complete. No share-key encryption needed.
+            let data: Data = try await withCheckedThrowingContinuation { cont in
+                provider.loadDataRepresentation(forTypeIdentifier: uti) { data, error in
+                    if let error { cont.resume(throwing: error); return }
+                    guard let data else { cont.resume(throwing: ShareError.noData); return }
+                    cont.resume(returning: data)
+                }
             }
-            try (destURL as NSURL).setResourceValue(
-                URLFileProtection.complete,
-                forKey: .fileProtectionKey
-            )
+            try data.write(to: destURL, options: .completeFileProtection)
         } catch {
             try? fm.removeItem(at: destURL)
             self.extensionContext?.cancelRequest(withError: ShareError.noData)


### PR DESCRIPTION
## Summary

- **v4 binary wire format** — eliminates 3-layer base64 inflation that was bloating bundle sizes; adds estimated bundle size label in compose view
- **AttachmentManager** — new service handling chunked AES-GCM encryption for all file attachments at rest; share extension session files now encrypted with `ShareIndexKeyManager`
- **Video** — inline `VideoPlayer` in message bubbles, thumbnail preview during compose, `NSItemProvider` streaming with `MADV_DONTNEED` page reclaim to fix OOM crash on large imports, `finishLoading()` fix for video not loading
- **Temp file hygiene** — `NSFileProtection` on all tmp writes, staging files encrypted with per-session key, `clearTemporaryDirectory` fixed (was silently aborting on first error), sweep on every app launch, files deleted as soon as no longer needed, tmp files excluded from iCloud backup
- **Composer refactor** — shared `ComposeViewModel`, unified V2 style, mode-aware text handling, thread compose state lifted to `Contact.DetailsV2`
- **Bug fixes** — fullscreen viewer showing encrypted data instead of decoded image, image bubble stuck on spinner after re-entering thread, invisible filenames in light mode, `onDisappear` clearing thread staging files, compose state not clearing on cancel, `Contact.Detail` v1 missed call site, `@MainActor` isolation cascade in `AttachmentManager`
- **Thread delete** — added delete option to threads
- **Docs** — bundle spec, video OOM investigation, video transcode pipeline spec, security checklist update requiring total at-rest encryption

## Test plan

- [ ] Send an image and video from v4 sender to v4 receiver — confirm no base64 bloat in bundle size label
- [ ] Import a large video (>100 MB) — confirm no OOM crash; playback works inline in the bubble
- [ ] Send a video — thumbnail visible in compose; seamless pending→final transition (no blank frame)
- [ ] Open fullscreen image viewer — confirm decoded image, not encrypted bytes
- [ ] Re-enter thread composer after sending an image — confirm no spinner stuck
- [ ] Cancel compose mid-draft — confirm staging files cleared, no `.occ` leaks in tmp
- [ ] Share a file via the Share Extension — confirm session index file is encrypted on disk
- [ ] Kill and relaunch app — confirm tmp directory swept
- [ ] Light mode: image/video bubble filenames visible
- [ ] Delete a thread — confirm it disappears and leaves no orphaned files
- [ ] All unit tests pass (`Cmd+U`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)